### PR TITLE
Boxing Non-Nullable Types When Copying into a DataSet

### DIFF
--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -78,15 +78,15 @@ namespace Excel.Core
                     continue;
                 }
                 DataTable newTable = null;
-				var columnCount = table.Columns.Count;
-				for (int i = 0; i < table.Columns.Count; i++)
+                for (int i = 0; i < table.Columns.Count; i++)
                 {
-					var columnMustBeNullable = false;
                     Type type = null;
+					var columnMustBeNullable = false;
                     foreach (DataRow row  in table.Rows)
                     {
 						if (row.IsNull (i)) {
 							columnMustBeNullable = true;
+							continue;
 						}
                         var curType = row[i].GetType();
                         if (curType != type)
@@ -105,9 +105,9 @@ namespace Excel.Core
                         convert = true;
                         if (newTable == null)
                             newTable = table.Clone();
-						newTable.Columns[i].DataType = type;
+                        newTable.Columns[i].DataType = type;
 						if (columnMustBeNullable
-						    && !(type.IsGenericType && type.GetGenericTypeDefinition () == typeof(Nullable<>))) {
+							&& !(type.IsGenericType && type.GetGenericTypeDefinition () == typeof(Nullable<>))) {
 							newTable.Columns [i].DataType = typeof(String);
 						}
                     }

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -81,15 +81,12 @@ namespace Excel.Core
                 for (int i = 0; i < table.Columns.Count; i++)
                 {
                     Type type = null;
-					#if __MonoCS__
 					var columnMustBeNullable = false;
-					#endif
                     foreach (DataRow row  in table.Rows)
                     {
 						if (row.IsNull (i)) {
-							#if __MonoCS__
 							columnMustBeNullable = true;
-							#else
+							#if !__MonoCS__
 							row [i] = String.Empty;
 							#endif
 							continue;
@@ -118,8 +115,9 @@ namespace Excel.Core
 								|| type.IsPrimitive ) {
 								newTable.Columns [i].DataType = typeof(Nullable<>).MakeGenericType (type);
 							}
-							#endif
+							#else
 							newTable.Columns [i].DataType = typeof(String);
+							#endif
 						}
                     }
                 }

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -106,9 +106,11 @@ namespace Excel.Core
                         if (newTable == null)
                             newTable = table.Clone();
                         newTable.Columns[i].DataType = type;
-						if (columnMustBeNullable
-							&& !(type.IsGenericType && type.GetGenericTypeDefinition () == typeof(Nullable<>))) {
-							newTable.Columns [i].DataType = typeof(String);
+						if (columnMustBeNullable) {
+							if ( (type.IsGenericType && !(type.GetGenericTypeDefinition () == typeof(Nullable<>)))
+								|| type.IsPrimitive ) {
+								newTable.Columns [i].DataType = typeof(Nullable<>).MakeGenericType (type);
+							}
 						}
                     }
                 }

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -87,17 +87,11 @@ namespace Excel.Core
                     foreach (DataRow row  in table.Rows)
                     {
 						if (row.IsNull (i)) {
-//							#if __MonoCS__
+							#if __MonoCS__
 							columnMustBeNullable = true;
-//							#else
-//							if ( null != type ) {
-//								object o = row[i];
-//								if ( null == o || o is DBNull ) {
-//									o = String.Empty;
-//								}
-//								row[i] = Convert.ChangeType(o, type);
-//							}
-//							#endif
+							#else
+							row [i] = String.Empty;
+							#endif
 							continue;
 						}
                         var curType = row[i].GetType();

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -90,7 +90,9 @@ namespace Excel.Core
 							#if __MonoCS__
 							columnMustBeNullable = true;
 							#else
-							row[i] = row[i].ToString();
+							if ( null != type ) {
+								row[i] = Convert.ChangeType(row[i], type);
+							}
 							#endif
 							continue;
 						}

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -86,12 +86,14 @@ namespace Excel.Core
 					#endif
                     foreach (DataRow row  in table.Rows)
                     {
-						#if __MonoCS__
 						if (row.IsNull (i)) {
+							#if __MonoCS__
 							columnMustBeNullable = true;
+							#else
+							row[i] = row[i].ToString();
+							#endif
 							continue;
 						}
-						#endif
                         var curType = row[i].GetType();
                         if (curType != type)
                         {

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -91,7 +91,11 @@ namespace Excel.Core
 							columnMustBeNullable = true;
 							#else
 							if ( null != type ) {
-								row[i] = Convert.ChangeType(row[i], type);
+								object o = row[i];
+								if ( null == o || o is typeof(DBNull) ) {
+									o = String.Empty;
+								}
+								row[i] = Convert.ChangeType(o, type);
 							}
 							#endif
 							continue;

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -78,13 +78,16 @@ namespace Excel.Core
                     continue;
                 }
                 DataTable newTable = null;
-                for (int i = 0; i < table.Columns.Count; i++)
+				var columnCount = table.Columns.Count;
+				for (int i = 0; i < table.Columns.Count; i++)
                 {
+					var columnMustBeNullable = false;
                     Type type = null;
                     foreach (DataRow row  in table.Rows)
                     {
-                        if (row.IsNull(i))
-                            continue;
+						if (row.IsNull (i)) {
+							columnMustBeNullable = true;
+						}
                         var curType = row[i].GetType();
                         if (curType != type)
                         {
@@ -102,8 +105,11 @@ namespace Excel.Core
                         convert = true;
                         if (newTable == null)
                             newTable = table.Clone();
-                        newTable.Columns[i].DataType = type;
-
+						newTable.Columns[i].DataType = type;
+						if (columnMustBeNullable
+						    && !(type.IsGenericType && type.GetGenericTypeDefinition () == typeof(Nullable<>))) {
+							newTable.Columns [i].DataType = typeof(String);
+						}
                     }
                 }
                 if (newTable != null)

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -81,13 +81,17 @@ namespace Excel.Core
                 for (int i = 0; i < table.Columns.Count; i++)
                 {
                     Type type = null;
+					#if __MonoCS__
 					var columnMustBeNullable = false;
+					#endif
                     foreach (DataRow row  in table.Rows)
                     {
+						#if __MonoCS__
 						if (row.IsNull (i)) {
 							columnMustBeNullable = true;
 							continue;
 						}
+						#endif
                         var curType = row[i].GetType();
                         if (curType != type)
                         {
@@ -106,12 +110,14 @@ namespace Excel.Core
                         if (newTable == null)
                             newTable = table.Clone();
                         newTable.Columns[i].DataType = type;
+						#if __MonoCS__
 						if (columnMustBeNullable) {
 							if ( (type.IsGenericType && !(type.GetGenericTypeDefinition () == typeof(Nullable<>)))
 								|| type.IsPrimitive ) {
 								newTable.Columns [i].DataType = typeof(Nullable<>).MakeGenericType (type);
 							}
 						}
+						#endif
                     }
                 }
                 if (newTable != null)

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -110,14 +110,14 @@ namespace Excel.Core
                             newTable = table.Clone();
                         newTable.Columns[i].DataType = type;
 						if (columnMustBeNullable) {
-							#if __MonoCS__
 							if ( (type.IsGenericType && !(type.GetGenericTypeDefinition () == typeof(Nullable<>)))
 								|| type.IsPrimitive ) {
+								#if __MonoCS__
 								newTable.Columns [i].DataType = typeof(Nullable<>).MakeGenericType (type);
+								#else
+								newTable.Columns [i].DataType = typeof(String);
+								#endif
 							}
-							#else
-							newTable.Columns [i].DataType = typeof(String);
-							#endif
 						}
                     }
                 }

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -87,17 +87,17 @@ namespace Excel.Core
                     foreach (DataRow row  in table.Rows)
                     {
 						if (row.IsNull (i)) {
-							#if __MonoCS__
+//							#if __MonoCS__
 							columnMustBeNullable = true;
-							#else
-							if ( null != type ) {
-								object o = row[i];
-								if ( null == o || o is DBNull ) {
-									o = String.Empty;
-								}
-								row[i] = Convert.ChangeType(o, type);
-							}
-							#endif
+//							#else
+//							if ( null != type ) {
+//								object o = row[i];
+//								if ( null == o || o is DBNull ) {
+//									o = String.Empty;
+//								}
+//								row[i] = Convert.ChangeType(o, type);
+//							}
+//							#endif
 							continue;
 						}
                         var curType = row[i].GetType();
@@ -118,14 +118,15 @@ namespace Excel.Core
                         if (newTable == null)
                             newTable = table.Clone();
                         newTable.Columns[i].DataType = type;
-						#if __MonoCS__
 						if (columnMustBeNullable) {
+							#if __MonoCS__
 							if ( (type.IsGenericType && !(type.GetGenericTypeDefinition () == typeof(Nullable<>)))
 								|| type.IsPrimitive ) {
 								newTable.Columns [i].DataType = typeof(Nullable<>).MakeGenericType (type);
 							}
+							#endif
+							newTable.Columns [i].DataType = typeof(String);
 						}
-						#endif
                     }
                 }
                 if (newTable != null)

--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -92,7 +92,7 @@ namespace Excel.Core
 							#else
 							if ( null != type ) {
 								object o = row[i];
-								if ( null == o || o is typeof(DBNull) ) {
+								if ( null == o || o is DBNull ) {
 									o = String.Empty;
 								}
 								row[i] = Convert.ChangeType(o, type);

--- a/Excel/Core/ZipWorker.cs
+++ b/Excel/Core/ZipWorker.cs
@@ -199,7 +199,8 @@ namespace Excel.Core
 
 		private void ExtractZipEntry(ZipFile zipFile, ZipEntry entry)
 		{
-			if (!entry.IsCompressionMethodSupported() || string.IsNullOrEmpty(entry.Name)) return;
+//			if (!entry.IsCompressionMethodSupported() || string.IsNullOrEmpty(entry.Name)) return;
+			if ( string.IsNullOrEmpty(entry.Name)) return;
 
 			string tPath = Path.Combine(_tempPath, entry.Name);
 			string path = entry.IsDirectory ? tPath : Path.GetDirectoryName(Path.GetFullPath(tPath));

--- a/Excel/Excel.4.5.csproj
+++ b/Excel/Excel.4.5.csproj
@@ -47,7 +47,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="ICSharpCode.SharpZipLib" />
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\BinaryFormat\Enums.cs" />

--- a/Excel/Excel.4.5.csproj
+++ b/Excel/Excel.4.5.csproj
@@ -47,6 +47,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="ICSharpCode.SharpZipLib" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\BinaryFormat\Enums.cs" />

--- a/Excel/Excel.4.5.csproj
+++ b/Excel/Excel.4.5.csproj
@@ -47,9 +47,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\BinaryFormat\Enums.cs" />

--- a/Excel/Excel.4.5.csproj
+++ b/Excel/Excel.4.5.csproj
@@ -47,7 +47,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="ICSharpCode.SharpZipLib" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\BinaryFormat\Enums.cs" />

--- a/Excel/Excel.4.5.csproj
+++ b/Excel/Excel.4.5.csproj
@@ -40,10 +40,6 @@
     <AssemblyOriginatorKeyFile>Excel.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -51,6 +47,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\BinaryFormat\Enums.cs" />

--- a/Excel/packages.config
+++ b/Excel/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+</packages>

--- a/Excel/packages.config
+++ b/Excel/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Using this under .NET 4.5 (Mono), IExcelDataReader.AsDataSet would fail with a NullPointerException when a non-nullable data typed column encountered a null value.

For example, the following CSV would result in a DoubleDataContainer.DoCopy Null Pointer Exception:

"1","List Item One",
"","List Item Two"

Because the first column was typed "double", but the second row had an empty value.

The platform appropriate solution was to  convert the identified type (T) to Nullable<T>.

Maybe the MS .NET framework is more lenient for DBNull values inside data sets, or does the wrapping automatically? I don't have access to Visual Studio so wasn't able to add a test case for this.
