### PR TITLE
Set Column.Caption to original read columnName (Dont hand duplcate for Caption)

### DIFF
--- a/Excel/Core/Helpers.cs
+++ b/Excel/Core/Helpers.cs
@@ -140,7 +140,7 @@ namespace ExcelDataReader.Portable.Core
 				i++;
 			}
 
-			table.Columns.Add(adjustedColumnName, typeof(Object));
+			table.Columns.Add(new DataColumn(adjustedColumnName, typeof(Object)) { Caption = columnName });
 		}
     }
 }


### PR DESCRIPTION
Currently I am needing to read a excel file, where in some situations there is duplicate columns, but the actual duplicate header as in the excel file, is still required inside the DataTable after being read. THis change would keep the Column.ColumnName as per the original code, where by duplicates are still handled, but the Column.Caption (which by default is the same as the Column.ColumnName) is then set to the original column name read from Excel. This does not break any tests, but would allow query the datatable.columns for columns that have the same header, and then get the column.name to read the unique values.