### PR TITLE
Uses MemoryStream as an option for ExcelOpenXmlReader

### DIFF
--- a/Excel.4.5/ExcelBinaryReader.cs
+++ b/Excel.4.5/ExcelBinaryReader.cs
@@ -318,11 +318,15 @@ namespace Excel
 	}
 
 	/// <summary>
-	/// Strict is as normal, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file. It will be trunacted in this case (SQl Reporting Services)
+	/// Strict is as normal, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file.
+	/// It will be trunacted in this case (SQl Reporting Services)
+	/// FileSystem is default for OpenXml.
 	/// </summary>
 	public enum ReadOption
 	{
 		Strict,
-		Loose
+		Loose,
+		FileSystem,
+		Memory
 	}
 }

--- a/Excel.4.5/ExcelBinaryReader.cs
+++ b/Excel.4.5/ExcelBinaryReader.cs
@@ -318,9 +318,9 @@ namespace Excel
 	}
 
 	/// <summary>
-	/// Strict is as normal, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file.
-	/// It will be trunacted in this case (SQl Reporting Services)
-	/// FileSystem is default for OpenXml.
+	/// Strict is as normal for <see cref="ExcelBinaryReader"/>, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file.
+	/// It will be truncated in this case (SQL Reporting Services).
+	/// FileSystem is default for <see cref="ExcelOpenXmlReader"/>.
 	/// </summary>
 	public enum ReadOption
 	{

--- a/Excel.4.5/ExcelOpenXmlReader.cs
+++ b/Excel.4.5/ExcelOpenXmlReader.cs
@@ -78,6 +78,13 @@ namespace Excel
 	        get { return portable.DefaultEncoding; }
 	    }
 
+        public ExcelDataReader.Portable.ReadOption SheetReadOption { get; private set; }
+
+        public ReadOption ReadOption
+        {
+            get { return (ReadOption)portable.ReadOption; }
+        }
+
 	    public bool IsValid
 		{
 			get { return portable.IsValid; }

--- a/Excel.4.5/ExcelReaderFactory.cs
+++ b/Excel.4.5/ExcelReaderFactory.cs
@@ -63,6 +63,7 @@ namespace Excel
         /// Creates an instance of <see cref="ExcelBinaryReader"/>
         /// </summary>
         /// <param name="fileStream">The file stream.</param>
+        /// <param name="option"></param>
         /// <returns></returns>
         public static IExcelDataReader CreateBinaryReader(Stream fileStream, ReadOption option)
 		{
@@ -120,5 +121,22 @@ namespace Excel
 
 			return new ExcelOpenXmlReader(reader);
 		}
+
+		/// <summary>
+		/// Creates an instance of <see cref="ExcelOpenXmlReader"/>
+		/// </summary>
+		/// <param name="fileStream">The file stream.</param>
+		/// <param name="option"></param>
+		/// <returns></returns>
+		public static IExcelDataReader CreateOpenXmlReader(Stream fileStream, ReadOption option)
+		{
+			var factory = CreateFactory();
+
+			var portableReadOption = (ExcelDataReader.Portable.ReadOption)option;
+			var reader = AsyncHelper.RunSync(() => factory.CreateOpenXmlReader(fileStream, portableReadOption));
+
+			return new ExcelOpenXmlReader(reader);
+		}
+
 	}
 }

--- a/Excel/Core/ZipWorker.cs
+++ b/Excel/Core/ZipWorker.cs
@@ -8,7 +8,7 @@ using System.Collections;
 
 namespace Excel.Core
 {
-	public class ZipWorker : IDisposable
+	public class ZipWorker : IExcelWorker
 	{
 		#region Members and Properties
 

--- a/Excel/Excel.csproj
+++ b/Excel/Excel.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Core\ReferenceHelper.cs" />
     <Compile Include="Core\BinaryFormat\XlsStringFactory.cs" />
     <Compile Include="Core\ZipWorker.cs" />
+    <Compile Include="Core\MemoryWorker.cs" />
     <Compile Include="Exceptions\BiffRecordException.cs" />
     <Compile Include="Exceptions\HeaderException.cs" />
     <Compile Include="Core\BinaryFormat\XlsFat.cs" />
@@ -198,6 +199,7 @@
     <Compile Include="ExcelBinaryReader.cs" />
     <Compile Include="ExcelReaderFactory.cs" />
     <Compile Include="IExcelDataReader.cs" />
+    <Compile Include="IExcelWorker.cs" />
     <Compile Include="ExcelOpenXmlReader.cs" />
     <Compile Include="Log\ILog.cs" />
     <Compile Include="Log\Log.cs" />

--- a/Excel/ExcelBinaryReader.cs
+++ b/Excel/ExcelBinaryReader.cs
@@ -1256,11 +1256,15 @@ namespace Excel
 	}
 
 	/// <summary>
-	/// Strict is as normal, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file. It will be trunacted in this case (SQl Reporting Services)
+	/// Strict is as normal for <see cref="ExcelBinaryReader"/>, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file.
+	/// It will be truncated in this case (SQL Reporting Services).
+	/// FileSystem is default for <see cref="ExcelOpenXmlReader"/>.
 	/// </summary>
 	public enum ReadOption
 	{
 		Strict,
-		Loose
+		Loose,
+		FileSystem,
+		Memory
 	}
 }

--- a/Excel/ExcelOpenXmlReader.cs
+++ b/Excel/ExcelOpenXmlReader.cs
@@ -26,7 +26,7 @@ namespace Excel
 		private int _depth;
 		private int _resultIndex;
 		private int _emptyRowCount;
-		private ZipWorker _zipWorker;
+		private IExcelWorker _zipWorker;
 		private XmlReader _xmlReader;
 		private Stream _sheetStream;
 		private object[] _cellsValues;
@@ -39,7 +39,8 @@ namespace Excel
 
 		private List<int> _defaultDateTimeStyles;
 		private string _namespaceUri;
-	    private Encoding defaultEncoding = Encoding.UTF8;
+		private Encoding defaultEncoding = Encoding.UTF8;
+		private readonly ReadOptionOpenXml m_ReadOption = ReadOptionOpenXml.FileSystem;
 
 	    #endregion
 
@@ -53,6 +54,11 @@ namespace Excel
 				14, 15, 16, 17, 18, 19, 20, 21, 22, 45, 46, 47
 			});
 
+		}
+
+		internal ExcelOpenXmlReader(ReadOptionOpenXml readOption) : this()
+		{
+			m_ReadOption = readOption;
 		}
 
 		private void ReadGlobals()
@@ -331,7 +337,11 @@ namespace Excel
 
 		public void Initialize(System.IO.Stream fileStream)
 		{
-			_zipWorker = new ZipWorker();
+			if (ReadOption == ReadOptionOpenXml.FileSystem)
+				_zipWorker = new ZipWorker();
+			else if (ReadOption == ReadOptionOpenXml.Memory)
+				_zipWorker = new MemoryWorker();
+			else throw new Exception("Unsopported ReadOption, please use FileSystem or Memory instead");
 			_zipWorker.Extract(fileStream);
 
 			if (!_zipWorker.IsValid)
@@ -405,6 +415,11 @@ namespace Excel
             dataset.AcceptChanges();
 		    Helpers.FixDataTypes(dataset);
 			return dataset;
+		}
+
+		public ReadOptionOpenXml ReadOption
+		{
+			get { return m_ReadOption; }
 		}
 
 		public bool IsFirstRowAsColumnNames
@@ -718,7 +733,14 @@ namespace Excel
 		}
 
 		#endregion
+	}
 
-
+	/// <summary>
+	/// FileSystem is default.
+	/// </summary>
+	public enum ReadOptionOpenXml
+	{
+		FileSystem,
+		Memory
 	}
 }

--- a/Excel/ExcelOpenXmlReader.cs
+++ b/Excel/ExcelOpenXmlReader.cs
@@ -341,7 +341,7 @@ namespace Excel
 				_zipWorker = new ZipWorker();
 			else if (ReadOption == ReadOption.Memory)
 				_zipWorker = new MemoryWorker();
-			else throw new Exception("Unsopported ReadOption, please use FileSystem or Memory instead");
+			else throw new Exception("Unsupported ReadOption, please use FileSystem or Memory instead");
 			_zipWorker.Extract(fileStream);
 
 			if (!_zipWorker.IsValid)

--- a/Excel/ExcelOpenXmlReader.cs
+++ b/Excel/ExcelOpenXmlReader.cs
@@ -40,7 +40,7 @@ namespace Excel
 		private List<int> _defaultDateTimeStyles;
 		private string _namespaceUri;
 		private Encoding defaultEncoding = Encoding.UTF8;
-		private readonly ReadOptionOpenXml m_ReadOption = ReadOptionOpenXml.FileSystem;
+		private readonly ReadOption m_ReadOption = ReadOption.FileSystem;
 
 	    #endregion
 
@@ -56,7 +56,7 @@ namespace Excel
 
 		}
 
-		internal ExcelOpenXmlReader(ReadOptionOpenXml readOption) : this()
+		internal ExcelOpenXmlReader(ReadOption readOption) : this()
 		{
 			m_ReadOption = readOption;
 		}
@@ -337,9 +337,9 @@ namespace Excel
 
 		public void Initialize(System.IO.Stream fileStream)
 		{
-			if (ReadOption == ReadOptionOpenXml.FileSystem)
+			if (ReadOption == ReadOption.FileSystem)
 				_zipWorker = new ZipWorker();
-			else if (ReadOption == ReadOptionOpenXml.Memory)
+			else if (ReadOption == ReadOption.Memory)
 				_zipWorker = new MemoryWorker();
 			else throw new Exception("Unsopported ReadOption, please use FileSystem or Memory instead");
 			_zipWorker.Extract(fileStream);
@@ -417,7 +417,7 @@ namespace Excel
 			return dataset;
 		}
 
-		public ReadOptionOpenXml ReadOption
+		public ReadOption ReadOption
 		{
 			get { return m_ReadOption; }
 		}
@@ -733,14 +733,5 @@ namespace Excel
 		}
 
 		#endregion
-	}
-
-	/// <summary>
-	/// FileSystem is default.
-	/// </summary>
-	public enum ReadOptionOpenXml
-	{
-		FileSystem,
-		Memory
 	}
 }

--- a/Excel/ExcelReaderFactory.cs
+++ b/Excel/ExcelReaderFactory.cs
@@ -28,6 +28,7 @@ namespace Excel
 		/// Creates an instance of <see cref="ExcelBinaryReader"/>
 		/// </summary>
 		/// <param name="fileStream">The file stream.</param>
+		/// <param name="option"></param>
 		/// <returns></returns>
 		public static IExcelDataReader CreateBinaryReader(Stream fileStream, ReadOption option)
 		{
@@ -54,6 +55,7 @@ namespace Excel
 		/// Creates an instance of <see cref="ExcelBinaryReader"/>
 		/// </summary>
 		/// <param name="fileStream">The file stream.</param>
+		/// <param name="readOption"></param>
 		/// <returns></returns>
 		public static IExcelDataReader CreateBinaryReader(Stream fileStream, bool convertOADate, ReadOption readOption)
 		{
@@ -71,6 +73,20 @@ namespace Excel
 		public static IExcelDataReader CreateOpenXmlReader(Stream fileStream)
 		{
 			IExcelDataReader reader = new ExcelOpenXmlReader();
+			reader.Initialize(fileStream);
+
+			return reader;
+		}
+
+		/// <summary>
+		/// Creates an instance of <see cref="ExcelOpenXmlReader"/>
+		/// </summary>
+		/// <param name="fileStream">The file stream.</param>
+		/// <param name="option"></param>
+		/// <returns></returns>
+		public static IExcelDataReader CreateOpenXmlReader(Stream fileStream, ReadOption option)
+		{
+			IExcelDataReader reader = new ExcelOpenXmlReader(option);
 			reader.Initialize(fileStream);
 
 			return reader;

--- a/Excel/IExcelWorker.cs
+++ b/Excel/IExcelWorker.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Excel
+{
+    public interface IExcelWorker : IDisposable
+    {
+        /// <summary>
+        /// Gets a value indicating whether this instance is valid.
+        /// </summary>
+        /// <value><c>true</c> if this instance is valid; otherwise, <c>false</c>.</value>
+        bool IsValid { get; }
+
+        /// <summary>
+        /// Gets the exception message.
+        /// </summary>
+        /// <value>The exception message.</value>
+        string ExceptionMessage { get; }
+
+        /// <summary>
+        /// Extracts the specified zip file stream.
+        /// </summary>
+        /// <param name="fileStream">The zip file stream.</param>
+        /// <returns></returns>
+        bool Extract(Stream fileStream);
+
+        /// <summary>
+        /// Gets the shared strings stream.
+        /// </summary>
+        /// <returns></returns>
+        Stream GetSharedStringsStream();
+
+        /// <summary>
+        /// Gets the styles stream.
+        /// </summary>
+        /// <returns></returns>
+        Stream GetStylesStream();
+
+        /// <summary>
+        /// Gets the workbook stream.
+        /// </summary>
+        /// <returns></returns>
+        Stream GetWorkbookStream();
+
+        /// <summary>
+        /// Gets the worksheet stream.
+        /// </summary>
+        /// <param name="sheetId">The sheet id.</param>
+        /// <returns></returns>
+        Stream GetWorksheetStream(int sheetId);
+
+        /// <summary>
+        /// Gets the worksheet stream.
+        /// </summary>
+        /// <param name="sheetId">The sheet path.</param>
+        /// <returns></returns>
+        Stream GetWorksheetStream(string sheetPath);
+
+        /// <summary>
+        /// Gets the workbook rels stream.
+        /// </summary>
+        /// <returns></returns>
+        Stream GetWorkbookRelsStream();
+    }
+}

--- a/ExcelDataReader.Portable/Core/MemoryWorker.cs
+++ b/ExcelDataReader.Portable/Core/MemoryWorker.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using System.Collections;
+
+namespace ExcelDataReader.Portable.Core
+{
+    public class MemoryWorker : IExcelWorker
+    {
+        #region Members and Properties
+
+        private byte[] buffer;
+
+        private bool disposed;
+
+        private const string TMP = "TMP_Z";
+        //private const string FOLDER_xl = "xl";
+        //private const string FOLDER_worksheets = "worksheets";
+        //private const string FILE_sharedStrings = "sharedStrings.{0}";
+        //private const string FILE_styles = "styles.{0}";
+        //private const string FILE_workbook = "workbook.{0}";
+        //private const string FILE_sheet = "sheet{0}.{1}";
+        //private const string FOLDER_rels = "_rels";
+        //private const string FILE_rels = "workbook.{0}.rels";
+
+        private string _exceptionMessage;
+
+        private bool _isValid;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is valid.
+        /// </summary>
+        /// <value><c>true</c> if this instance is valid; otherwise, <c>false</c>.</value>
+        public bool IsValid
+        {
+            get { return _isValid; }
+        }
+
+        /// <summary>
+        /// Gets the exception message.
+        /// </summary>
+        /// <value>The exception message.</value>
+        public string ExceptionMessage
+        {
+            get { return _exceptionMessage; }
+        }
+
+        #endregion
+
+        public MemoryWorker()
+        {
+            MemoryData.zipfilelist = new List<List<string>>();
+        }
+
+        public async Task<bool> Extract(Stream fileStream)
+        {
+            if (null == fileStream) return false;
+            _isValid = true;
+            ZipArchive zipFile = null; 
+            try
+            {
+                zipFile = new ZipArchive(fileStream);
+                IEnumerator enumerator = zipFile.Entries.GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    var entry = (ZipArchiveEntry)enumerator.Current;
+                    if (buffer == null)
+                    {
+                        buffer = new byte[0x1000];
+                    }
+                    List<string> zipfileitems = new List<string>();
+                    MemoryData.excelSavedFromAccessBool = false;
+                    using (StreamReader reader = new StreamReader(entry.Open()))
+                    {
+                        // Create our List and Populate it
+                        zipfileitems.Add(entry.ToString());
+                        try
+                        {
+                            zipfileitems.Add(reader.ReadToEnd());
+                        }
+                        catch (Exception ex)
+                        {
+                            _isValid = false;
+                            _exceptionMessage = ex.Message;
+                            throw;
+                        }
+                        finally
+                        {
+                            MemoryData.zipfilelist.Add(zipfileitems);
+                            reader.Dispose();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _isValid = false;
+                _exceptionMessage = ex.Message;
+            }
+            finally
+            {
+                fileStream.Dispose();
+
+                if (null != zipFile) zipFile.Dispose();
+            }
+            /*try
+            {
+                if (!Directory.Exists(TMP)) Directory.CreateDirectory(TMP);
+                foreach (List<string> file in MemoryData.zipfilelist)
+                {
+                    if (!String.IsNullOrEmpty(file[1]))
+                    {
+                        string path = Path.Combine(TMP, file[0]);
+                        string folder = Path.GetDirectoryName(path);
+                        if (!Directory.Exists(folder)) Directory.CreateDirectory(folder);
+                        File.WriteAllText(path, file[1], Encoding.UTF8);
+                    }
+                }
+            }
+            catch (Exception ex) { }*/
+            return  _isValid;
+        }
+
+        /// <summary>
+        /// Gets the shared strings stream.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Stream> GetSharedStringsStream()
+        {
+            string exelcontent = "xl/sharedStrings.xml";
+            return await getStream(exelcontent);
+        }
+
+        /// <summary>
+        /// Gets the styles stream.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Stream> GetStylesStream()
+        {
+            string exelcontent = "xl/styles.xml";
+            return await getStream(exelcontent);
+        }
+
+        /// <summary>
+        /// Gets the workbook stream.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Stream> GetWorkbookStream()
+        {
+            string exelcontent = "xl/workbook.xml";
+            return await getStream(exelcontent);
+        }
+
+        /// <summary>
+        /// Gets the worksheet stream.
+        /// </summary>
+        /// <param name="sheetId">The sheet id.</param>
+        /// <returns></returns>
+        public async Task<Stream> GetWorksheetStream(int sheetId)
+        {
+            return null;
+        }
+
+        public async Task<Stream> GetWorksheetStream(string sheetPath)
+        {
+            //its possible sheetPath starts with /xl. in this case trim the /xl
+            if (sheetPath.StartsWith("/xl/"))
+                sheetPath = sheetPath.Substring(4);
+            string exelcontent = "xl/" + sheetPath;
+            return await getStream(exelcontent);
+        }
+
+        /// <summary>
+        /// Gets the workbook rels stream.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Stream> GetWorkbookRelsStream()
+        {
+            string exelcontent = "xl/_rels/workbook.xml.rels";
+            return await getStream(exelcontent);
+        }
+
+        private MemoryStream getStreamFromString(string excelstring)
+        {
+            MemoryStream ms = new MemoryStream();
+            if (!String.IsNullOrEmpty(excelstring))
+            {
+                try
+                {
+                    Byte[] byteArray = Encoding.UTF8.GetBytes(excelstring);
+                    ms = new MemoryStream(byteArray);
+                    return ms;
+                }
+                catch (Exception ex)
+                {
+                    ms.Dispose();
+                    _exceptionMessage = ex.Message;
+                    throw;
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private async Task<Stream> getStream(string itemlist)
+        {
+            Stream data = null;
+            foreach (List<string> item in MemoryData.returnlist)
+            {
+                if (item.Contains(itemlist))
+                {
+                    data = getStreamFromString(item[1]);
+                    return data;
+                }
+            }
+            return data; // nothing to return
+        }
+
+        /*private static byte[] StringToBytes(string str)
+        {
+            byte[] data = new byte[str.Length * 2];
+            for (int i = 0; i < str.Length; ++i)
+            {
+                char ch = str[i]; data[i * 2] = (byte)(ch & 0xFF); data[i * 2 + 1] = (byte)((ch & 0xFF00) >> 8);
+            }
+            return data;
+        }*/
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            Dispose(true);
+
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            // Check to see if Dispose has already been called.
+            if (!this.disposed)
+            {
+                if (disposing)
+                {
+                }
+
+                buffer = null;
+
+                disposed = true;
+            }
+        }
+
+        ~MemoryWorker()
+        {
+            Dispose(false);
+        }
+
+        #endregion
+    }
+
+    internal class MemoryData
+    {
+        public static bool excelSavedFromAccessBool;
+
+        public static List<List<String>> zipfilelist = new List<List<String>>();
+
+        private static void zipfilelistadd(List<string> zipfileitems)
+        {
+            zipfilelist.Add(zipfileitems);
+        }
+
+        public static List<List<string>> returnlist
+        {
+            get { return zipfilelist; }
+        }
+    }
+}

--- a/ExcelDataReader.Portable/Core/MemoryWorker.cs
+++ b/ExcelDataReader.Portable/Core/MemoryWorker.cs
@@ -16,7 +16,7 @@ namespace ExcelDataReader.Portable.Core
 
         private bool disposed;
 
-        private const string TMP = "TMP_Z";
+        //private const string TMP = "TMP_Z";
         //private const string FOLDER_xl = "xl";
         //private const string FOLDER_worksheets = "worksheets";
         //private const string FILE_sharedStrings = "sharedStrings.{0}";
@@ -79,7 +79,7 @@ namespace ExcelDataReader.Portable.Core
                         zipfileitems.Add(entry.ToString());
                         try
                         {
-                            zipfileitems.Add(reader.ReadToEnd());
+                            zipfileitems.Add(await reader.ReadToEndAsync());
                         }
                         catch (Exception ex)
                         {
@@ -161,7 +161,8 @@ namespace ExcelDataReader.Portable.Core
         /// <returns></returns>
         public async Task<Stream> GetWorksheetStream(int sheetId)
         {
-            return null;
+            string excelcontent = "xl/worksheets/sheet" + sheetId + ".xml";
+            return await getStream(excelcontent);
         }
 
         public async Task<Stream> GetWorksheetStream(string sheetPath)
@@ -214,7 +215,7 @@ namespace ExcelDataReader.Portable.Core
             {
                 if (item.Contains(itemlist))
                 {
-                    data = getStreamFromString(item[1]);
+                    data = await Task.Run(() => getStreamFromString(item[1]));
                     return data;
                 }
             }

--- a/ExcelDataReader.Portable/Core/ZipWorker.cs
+++ b/ExcelDataReader.Portable/Core/ZipWorker.cs
@@ -11,7 +11,7 @@ using PCLStorage;
 
 namespace ExcelDataReader.Portable.Core
 {
-	public class ZipWorker : IDisposable
+	public class ZipWorker : IExcelWorker
 	{
 	    private readonly IFileSystem fileSystem;
 	    private readonly IFileHelper fileHelper;

--- a/ExcelDataReader.Portable/ExcelBinaryReader.cs
+++ b/ExcelDataReader.Portable/ExcelBinaryReader.cs
@@ -802,6 +802,9 @@ namespace ExcelDataReader.Portable
 
 		public async Task InitializeAsync(Stream fileStream)
 		{
+			if (ReadOption == ReadOption.FileSystem || ReadOption == ReadOption.Memory)
+				throw new Exception("Unsopported ReadOption, please use Strict or Loose instead");
+
 			m_file = fileStream;
 
             await Task.Run(() => readWorkBookGlobals());
@@ -1463,12 +1466,16 @@ namespace ExcelDataReader.Portable
         }
     }
 
-    /// <summary>
-	/// Strict is as normal, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file. It will be trunacted in this case (SQl Reporting Services)
+	/// <summary>
+	/// Strict is as normal, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file.
+	/// It will be trunacted in this case (SQl Reporting Services).
+	/// FileSystem is default for OpenXml.
 	/// </summary>
 	public enum ReadOption
 	{
 		Strict,
-		Loose
+		Loose,
+		FileSystem,
+		Memory
 	}
 }

--- a/ExcelDataReader.Portable/ExcelBinaryReader.cs
+++ b/ExcelDataReader.Portable/ExcelBinaryReader.cs
@@ -1467,9 +1467,9 @@ namespace ExcelDataReader.Portable
     }
 
 	/// <summary>
-	/// Strict is as normal, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file.
-	/// It will be trunacted in this case (SQl Reporting Services).
-	/// FileSystem is default for OpenXml.
+	/// Strict is as normal for <see cref="ExcelBinaryReader"/>, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file.
+	/// It will be truncated in this case (SQL Reporting Services).
+	/// FileSystem is default for <see cref="ExcelOpenXmlReader"/>.
 	/// </summary>
 	public enum ReadOption
 	{

--- a/ExcelDataReader.Portable/ExcelBinaryReader.cs
+++ b/ExcelDataReader.Portable/ExcelBinaryReader.cs
@@ -803,7 +803,7 @@ namespace ExcelDataReader.Portable
 		public async Task InitializeAsync(Stream fileStream)
 		{
 			if (ReadOption == ReadOption.FileSystem || ReadOption == ReadOption.Memory)
-				throw new Exception("Unsopported ReadOption, please use Strict or Loose instead");
+				throw new Exception("Unsupported ReadOption, please use Strict or Loose instead");
 
 			m_file = fileStream;
 

--- a/ExcelDataReader.Portable/ExcelDataReader.Portable.csproj
+++ b/ExcelDataReader.Portable/ExcelDataReader.Portable.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Core\ReferenceHelper.cs" />
     <Compile Include="Core\StringHelper.cs" />
     <Compile Include="Core\ZipWorker.cs" />
+    <Compile Include="Core\MemoryWorker.cs" />
     <Compile Include="Data\IDataHelper.cs" />
     <Compile Include="Data\IDataReader.cs" />
     <Compile Include="Data\IDataRecord.cs" />
@@ -208,6 +209,7 @@
     <Compile Include="Exceptions\BiffRecordException.cs" />
     <Compile Include="Exceptions\HeaderException.cs" />
     <Compile Include="IExcelDataReader.cs" />
+    <Compile Include="IExcelWorker.cs" />
     <Compile Include="IO\PCLStorage\FolderExtensions.cs" />
     <Compile Include="Misc\DateTimeHelper.cs" />
     <Compile Include="Misc\ListExtensions.cs" />

--- a/ExcelDataReader.Portable/ExcelOpenXmlReader.cs
+++ b/ExcelDataReader.Portable/ExcelOpenXmlReader.cs
@@ -33,11 +33,12 @@ namespace ExcelDataReader.Portable
 		private int _depth;
 		private int _resultIndex;
 		private int _emptyRowCount;
-		private ZipWorker _zipWorker;
+		private IExcelWorker _zipWorker;
 		private XmlReader _xmlReader;
 		private Stream _sheetStream;
 		private object[] _cellsValues;
 		private object[] _savedCellsValues;
+		private ReadOption readOption = ReadOption.FileSystem;
 
 		private bool disposed;
 		private bool _isFirstRowAsColumnNames;
@@ -340,9 +341,13 @@ namespace ExcelDataReader.Portable
 
 		public async Task InitializeAsync(System.IO.Stream fileStream)
 		{
-            _zipWorker = new ZipWorker(fileSystem, fileHelper);
+			if (ReadOption == ReadOption.FileSystem)
+				_zipWorker = new ZipWorker(fileSystem, fileHelper);
+			else if (ReadOption == ReadOption.Memory)
+				_zipWorker = new MemoryWorker();
+			else throw new Exception("Unsopported ReadOption, please use FileSystem or Memory instead");
 
-            await _zipWorker.Extract(fileStream);
+			await _zipWorker.Extract(fileStream);
 
 			if (!_zipWorker.IsValid)
 			{
@@ -434,7 +439,12 @@ namespace ExcelDataReader.Portable
 		}
 
 	    public bool ConvertOaDate { get; set; }
-	    public ReadOption ReadOption { get; set; }
+
+        public ReadOption ReadOption
+        {
+            get { return readOption; }
+            set { readOption = value; }
+        }
 
 	    public Encoding Encoding
 	    {

--- a/ExcelDataReader.Portable/ExcelOpenXmlReader.cs
+++ b/ExcelDataReader.Portable/ExcelOpenXmlReader.cs
@@ -345,7 +345,7 @@ namespace ExcelDataReader.Portable
 				_zipWorker = new ZipWorker(fileSystem, fileHelper);
 			else if (ReadOption == ReadOption.Memory)
 				_zipWorker = new MemoryWorker();
-			else throw new Exception("Unsopported ReadOption, please use FileSystem or Memory instead");
+			else throw new Exception("Unsupported ReadOption, please use FileSystem or Memory instead");
 
 			await _zipWorker.Extract(fileStream);
 

--- a/ExcelDataReader.Portable/ExcelReaderFactory.cs
+++ b/ExcelDataReader.Portable/ExcelReaderFactory.cs
@@ -88,5 +88,19 @@ namespace ExcelDataReader.Portable
 
 			return reader;
 		}
+
+        /// <summary>
+        /// Creates an instance of <see cref="ExcelOpenXmlReader"/>
+        /// </summary>
+        /// <param name="fileStream">The file stream.</param>
+        /// <returns></returns>
+        public async Task<IExcelDataReader> CreateOpenXmlReader(Stream fileStream, ReadOption option)
+        {
+            IExcelDataReader reader = new ExcelOpenXmlReader(fileSystem, fileHelper, dataHelper);
+            reader.ReadOption = option;
+            await reader.InitializeAsync(fileStream);
+
+            return reader;
+        }
 	}
 }

--- a/ExcelDataReader.Portable/ExcelReaderFactory.cs
+++ b/ExcelDataReader.Portable/ExcelReaderFactory.cs
@@ -89,18 +89,18 @@ namespace ExcelDataReader.Portable
 			return reader;
 		}
 
-        /// <summary>
-        /// Creates an instance of <see cref="ExcelOpenXmlReader"/>
-        /// </summary>
-        /// <param name="fileStream">The file stream.</param>
-        /// <returns></returns>
-        public async Task<IExcelDataReader> CreateOpenXmlReader(Stream fileStream, ReadOption option)
-        {
-            IExcelDataReader reader = new ExcelOpenXmlReader(fileSystem, fileHelper, dataHelper);
-            reader.ReadOption = option;
-            await reader.InitializeAsync(fileStream);
+		/// <summary>
+		/// Creates an instance of <see cref="ExcelOpenXmlReader"/>
+		/// </summary>
+		/// <param name="fileStream">The file stream.</param>
+		/// <returns></returns>
+		public async Task<IExcelDataReader> CreateOpenXmlReader(Stream fileStream, ReadOption option)
+		{
+			IExcelDataReader reader = new ExcelOpenXmlReader(fileSystem, fileHelper, dataHelper);
+			reader.ReadOption = option;
+			await reader.InitializeAsync(fileStream);
 
-            return reader;
-        }
+			return reader;
+		}
 	}
 }

--- a/ExcelDataReader.Portable/IExcelWorker.cs
+++ b/ExcelDataReader.Portable/IExcelWorker.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExcelDataReader.Portable
+{
+    public interface IExcelWorker : IDisposable
+    {
+        /// <summary>
+        /// Gets a value indicating whether this instance is valid.
+        /// </summary>
+        /// <value><c>true</c> if this instance is valid; otherwise, <c>false</c>.</value>
+        bool IsValid { get; }
+
+        /// <summary>
+        /// Gets the exception message.
+        /// </summary>
+        /// <value>The exception message.</value>
+        string ExceptionMessage { get; }
+
+        /// <summary>
+        /// Extracts the specified zip file stream.
+        /// </summary>
+        /// <param name="fileStream">The zip file stream.</param>
+        /// <returns></returns>
+        Task<bool> Extract(Stream fileStream);
+
+        /// <summary>
+        /// Gets the shared strings stream.
+        /// </summary>
+        /// <returns></returns>
+        Task<Stream> GetSharedStringsStream();
+
+        /// <summary>
+        /// Gets the styles stream.
+        /// </summary>
+        /// <returns></returns>
+        Task<Stream> GetStylesStream();
+
+        /// <summary>
+        /// Gets the workbook stream.
+        /// </summary>
+        /// <returns></returns>
+        Task<Stream> GetWorkbookStream();
+
+        /// <summary>
+        /// Gets the worksheet stream.
+        /// </summary>
+        /// <param name="sheetId">The sheet id.</param>
+        /// <returns></returns>
+        Task<Stream> GetWorksheetStream(int sheetId);
+
+        /// <summary>
+        /// Gets the worksheet stream.
+        /// </summary>
+        /// <param name="sheetId">The sheet path.</param>
+        /// <returns></returns>
+        Task<Stream> GetWorksheetStream(string sheetPath);
+
+        /// <summary>
+        /// Gets the workbook rels stream.
+        /// </summary>
+        /// <returns></returns>
+       Task<Stream> GetWorkbookRelsStream();
+    }
+}

--- a/excel/Core/MemoryWorker.cs
+++ b/excel/Core/MemoryWorker.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using Excel.Log;
+using ICSharpCode.SharpZipLib.Zip;
+using System.Collections;
+
+namespace Excel.Core
+{
+    public class MemoryWorker : IExcelWorker
+    {
+        #region Members and Properties
+
+        private byte[] buffer;
+
+        private bool disposed;
+
+        private const string TMP = "TMP_Z";
+        //private const string FOLDER_xl = "xl";
+        //private const string FOLDER_worksheets = "worksheets";
+        //private const string FILE_sharedStrings = "sharedStrings.{0}";
+        //private const string FILE_styles = "styles.{0}";
+        //private const string FILE_workbook = "workbook.{0}";
+        //private const string FILE_sheet = "sheet{0}.{1}";
+        //private const string FOLDER_rels = "_rels";
+        //private const string FILE_rels = "workbook.{0}.rels";
+
+        private string _exceptionMessage;
+
+        private bool _isValid;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is valid.
+        /// </summary>
+        /// <value><c>true</c> if this instance is valid; otherwise, <c>false</c>.</value>
+        public bool IsValid
+        {
+            get { return _isValid; }
+        }
+
+        /// <summary>
+        /// Gets the exception message.
+        /// </summary>
+        /// <value>The exception message.</value>
+        public string ExceptionMessage
+        {
+            get { return _exceptionMessage; }
+        }
+
+        #endregion
+
+        public MemoryWorker()
+        {
+            MemoryData.zipfilelist = new List<List<string>>();
+        }
+
+        public bool Extract(Stream fileStream)
+        {
+            if (null == fileStream) return false;
+            _isValid = true;
+            ZipFile zipFile = null;
+            try
+            {
+                zipFile = new ZipFile(fileStream);
+                IEnumerator enumerator = zipFile.GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    ZipEntry entry = (ZipEntry)enumerator.Current;
+                    if (buffer == null)
+                    {
+                        buffer = new byte[0x1000];
+                    }
+                    List<string> zipfileitems = new List<string>();
+                    MemoryData.excelSavedFromAccessBool = false;
+                    using (StreamReader reader = new StreamReader(zipFile.GetInputStream(entry)))
+                    {
+                        // Create our List and Populate it
+                        zipfileitems.Add(entry.ToString());
+                        //if (entry.Name.Contains("thumbnail.wmf"))
+                        //{
+                        //    MemoryData.excelSavedFromAccessBool = true;
+                        //    _isValid = false;
+                        //    break;
+                        //}
+                        #region output for debugging
+                        ////Console.Write("Name " + entry.Name.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("Type " + entry.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("AESKeySize " + entry.AESKeySize.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("CanDecompress " + entry.CanDecompress.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("CentralHeaderRequiresZip64 " + entry.CentralHeaderRequiresZip64.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("CompressedSize " + entry.CompressedSize.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("Crc " + entry.Crc.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("ExternalFileAttributes " + entry.ExternalFileAttributes.ToString());
+                        ////Console.Write("\r\n");
+                        //////   Console.Write("ExtraData " + entry.ExtraData.ToString());
+                        ////Console.Write("Flags " + entry.Flags.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("HasCrc " + entry.HasCrc.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("IsCrypted " + entry.IsCrypted.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("IsDirectory. " + entry.IsDirectory.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("IsFile " + entry.IsFile.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("VersionMadeBy " + entry.VersionMadeBy.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("ZipFileIndex " + entry.ZipFileIndex.ToString());
+                        ////Console.Write("\r\n");
+                        ////Console.Write("\r\n");
+                        ////Console.Write("\r\n");
+                        ////Console.Write("\r\n");
+                        ////Console.Write("\r\n");
+                        ////Console.Write("\r\n");
+                        ////Console.Write(" ----------------------------------------------------------");
+                        #endregion
+                        try
+                        {
+                            zipfileitems.Add(reader.ReadToEnd());
+                        }
+                        catch (Exception ex)
+                        {
+                            _isValid = false;
+                            _exceptionMessage = ex.Message;
+                            throw;
+                        }
+                        finally
+                        {
+                            MemoryData.zipfilelist.Add(zipfileitems);
+                            reader.Dispose();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _isValid = false;
+                _exceptionMessage = ex.Message;
+            }
+            finally
+            {
+                fileStream.Close();
+                if (null != zipFile) zipFile.Close();
+            }
+            /*try
+            {
+                if (!Directory.Exists(TMP)) Directory.CreateDirectory(TMP);
+                foreach (List<string> file in MemoryData.zipfilelist)
+                {
+                    if (!String.IsNullOrEmpty(file[1]))
+                    {
+                        string path = Path.Combine(TMP, file[0]);
+                        string folder = Path.GetDirectoryName(path);
+                        if (!Directory.Exists(folder)) Directory.CreateDirectory(folder);
+                        File.WriteAllText(path, file[1], Encoding.UTF8);
+                    }
+                }
+            }
+            catch (Exception ex) { }*/
+            return _isValid;
+        }
+
+        /// <summary>
+        /// Gets the shared strings stream.
+        /// </summary>
+        /// <returns></returns>
+        public Stream GetSharedStringsStream()
+        {
+            string exelcontent = "xl/sharedStrings.xml";
+            return getStream(exelcontent);
+        }
+
+        /// <summary>
+        /// Gets the styles stream.
+        /// </summary>
+        /// <returns></returns>
+        public Stream GetStylesStream()
+        {
+            string exelcontent = "xl/styles.xml";
+            return getStream(exelcontent);
+        }
+
+        /// <summary>
+        /// Gets the workbook stream.
+        /// </summary>
+        /// <returns></returns>
+        public Stream GetWorkbookStream()
+        {
+            string exelcontent = "xl/workbook.xml";
+            return getStream(exelcontent);
+        }
+
+        /// <summary>
+        /// Gets the worksheet stream.
+        /// </summary>
+        /// <param name="sheetId">The sheet id.</param>
+        /// <returns></returns>
+        public Stream GetWorksheetStream(int sheetId)
+        {
+            return null;
+        }
+
+        public Stream GetWorksheetStream(string sheetPath)
+        {
+            //its possible sheetPath starts with /xl. in this case trim the /xl
+            if (sheetPath.StartsWith("/xl/"))
+                sheetPath = sheetPath.Substring(4);
+            string exelcontent = "xl/" + sheetPath;
+            return getStream(exelcontent);
+        }
+
+        /// <summary>
+        /// Gets the workbook rels stream.
+        /// </summary>
+        /// <returns></returns>
+        public Stream GetWorkbookRelsStream()
+        {
+            string exelcontent = "xl/_rels/workbook.xml.rels";
+            return getStream(exelcontent);
+        }
+
+        private MemoryStream getStreamFromString(string excelstring)
+        {
+            MemoryStream ms = new MemoryStream();
+            if (!String.IsNullOrEmpty(excelstring))
+            {
+                try
+                {
+                    Byte[] byteArray = Encoding.UTF8.GetBytes(excelstring);
+                    ms = new MemoryStream(byteArray);
+                    return ms;
+                }
+                catch (Exception ex)
+                {
+                    ms.Dispose();
+                    _exceptionMessage = ex.Message;
+                    throw;
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private Stream getStream(string itemlist)
+        {
+            Stream data = null;
+            foreach (List<string> item in MemoryData.returnlist)
+            {
+                if (item.Contains(itemlist))
+                {
+                    data = getStreamFromString(item[1]);
+                    return data;
+                }
+            }
+            return data; // nothing to return
+        }
+
+        /*private static byte[] StringToBytes(string str)
+        {
+            byte[] data = new byte[str.Length * 2];
+            for (int i = 0; i < str.Length; ++i)
+            {
+                char ch = str[i]; data[i * 2] = (byte)(ch & 0xFF); data[i * 2 + 1] = (byte)((ch & 0xFF00) >> 8);
+            }
+            return data;
+        }*/
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            Dispose(true);
+
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            // Check to see if Dispose has already been called.
+            if (!this.disposed)
+            {
+                if (disposing)
+                {
+                }
+
+                buffer = null;
+
+                disposed = true;
+            }
+        }
+
+        ~MemoryWorker()
+        {
+            Dispose(false);
+        }
+
+        #endregion
+    }
+
+    internal class MemoryData
+    {
+        public static bool excelSavedFromAccessBool;
+
+        public static List<List<String>> zipfilelist = new List<List<String>>();
+
+        private static void zipfilelistadd(List<string> zipfileitems)
+        {
+            zipfilelist.Add(zipfileitems);
+        }
+
+        public static List<List<string>> returnlist
+        {
+            get { return zipfilelist; }
+        }
+    }
+}

--- a/excel/Core/MemoryWorker.cs
+++ b/excel/Core/MemoryWorker.cs
@@ -205,7 +205,8 @@ namespace Excel.Core
         /// <returns></returns>
         public Stream GetWorksheetStream(int sheetId)
         {
-            return null;
+            string excelcontent = "xl/worksheets/sheet" + sheetId + ".xml";
+            return getStream(excelcontent);
         }
 
         public Stream GetWorksheetStream(string sheetPath)


### PR DESCRIPTION
Credit for orginal idea goes to @prosenba (please read his post https://github.com/ExcelDataReader/ExcelDataReader/issues/104)

Added his in-memory routines for Portable/2.0/4.5 versions of the Library:
- IExcelWorker is the interface for both .NET 2.0 and Portable releases (ZipWorker and new MemoryWorker implement it)
- ReadOption is extended supporting new FileSystem and Memory options (Open Xml only)
- Open Xml reader creates the "worker" according to ReadOption

All tests passed (both "standard" ZipWorker and new in-memory worker).

Please note that I haven't modified Silverlight version (is it still supported?).
