### PR TITLE
Fix issue #170 with reading Cyrillic-encoded worksheet names in XLS files

### DIFF
--- a/Excel.Tests/App.config
+++ b/Excel.Tests/App.config
@@ -46,6 +46,7 @@
     <add key="Test_Issue_11818_OutOfRange" value="Test_Issue_11818_OutOfRange.xls" />
     <add key="Test_Excel_OpenOffice" value="Test_Excel_OpenOffice.xls" />
     <add key="Test_Git_Issue_70" value="Test_git_issue_70_ExcelBinaryReader_tryConvertOADateTime _convert_dates.xls" />
+    <add key="Test_CyrillicWorksheetName" value="Test_CyrillicWorksheetName.xls" />
     
     <!--<add key="Test_SSRS" value="Test_SSRS.xls"/>-->
     <add key="xTestOpenXml" value="TestOpenXml.xlsx" />

--- a/Excel.Tests/ExcelBinaryReaderTest.cs
+++ b/Excel.Tests/ExcelBinaryReaderTest.cs
@@ -1099,6 +1099,22 @@ namespace ExcelDataReader.Tests
 
             excelReader.Close();
 		}
-        
+
+        /// <summary>
+        /// Incorrect encoding of Cyrillic worksheet names in XLS files (issue #170)
+        /// </summary>
+        [TestMethod]
+        public void Test_CyrillicWorksheetName()
+        {
+            IExcelDataReader excelReader =
+                ExcelReaderFactory.CreateBinaryReader(Helper.GetTestWorkbook("Test_CyrillicWorksheetName"));
+            excelReader.IsFirstRowAsColumnNames = false;
+            var dataset = excelReader.AsDataSet();
+
+            Assert.AreEqual("Квадратичная функция", dataset.Tables[0].TableName);
+
+            excelReader.Close();
+        }
+
     }
 }

--- a/ExcelDataReader.Portable/ExcelBinaryReader.cs
+++ b/ExcelDataReader.Portable/ExcelBinaryReader.cs
@@ -217,7 +217,9 @@ namespace ExcelDataReader.Portable
                         //set encoding based on code page name
                         //PCL does not supported codepage numbers
                         if (m_globals.CodePage.Value == 1200)
-                            m_encoding = EncodingHelper.GetEncoding(65001);
+                            //m_encoding = EncodingHelper.GetEncoding(65001);
+                            m_encoding = EncodingHelper.GetEncoding(1200);//If the codepage value is 1200, then the workbook should be opened with encoding corresponding to code 1200.
+                            //Otherwise, there will be a worksheet name reading problem, for example, with Cyrillic names.
                         else
                             m_encoding = EncodingHelper.GetEncoding(m_globals.CodePage.Value);
                         //note: the format spec states that for BIFF8 this is always UTF-16.


### PR DESCRIPTION
Fixed issue #170 I opened recently. Cyrillic-encoded worksheet names are now properly displayed.
