### PR TITLE
Fixes issue #184: CreateBinaryReader will not throw exception with MemoryStreams of certain sizes

### DIFF
--- a/Excel.Tests.4.5/Excel.Tests.4.5.csproj
+++ b/Excel.Tests.4.5/Excel.Tests.4.5.csproj
@@ -348,6 +348,9 @@
     <Content Include="Resources\Test_Excel_OpenOffice.xlsx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="Resources\Test_git_issue_184_ExcelBinaryReader_ArgumentOutOfRangeException.xls">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Resources\Test_git_issue_70_ExcelBinaryReader_tryConvertOADateTime _convert_dates.xls">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Excel.Tests/App.config
+++ b/Excel.Tests/App.config
@@ -46,6 +46,7 @@
     <add key="Test_Issue_11818_OutOfRange" value="Test_Issue_11818_OutOfRange.xls" />
     <add key="Test_Excel_OpenOffice" value="Test_Excel_OpenOffice.xls" />
     <add key="Test_Git_Issue_70" value="Test_git_issue_70_ExcelBinaryReader_tryConvertOADateTime _convert_dates.xls" />
+    <add key="Test_Git_Issue_184" value="Test_git_issue_184_ExcelBinaryReader_ArgumentOutOfRangeException.xls" />
     
     <!--<add key="Test_SSRS" value="Test_SSRS.xls"/>-->
     <add key="xTestOpenXml" value="TestOpenXml.xlsx" />

--- a/Excel.Tests/ExcelBinaryReaderTest.cs
+++ b/Excel.Tests/ExcelBinaryReaderTest.cs
@@ -77,6 +77,22 @@ namespace ExcelDataReader.Tests
             Assert.AreEqual("visible", dataset.Tables[1].ExtendedProperties["visiblestate"]);
             Assert.AreEqual("veryhidden", dataset.Tables[2].ExtendedProperties["visiblestate"]);
         }
+
+        [TestMethod]
+        public void GitIssue_184_ArgumentOutOfRangeException()
+        {
+            // The issue is only reproduced using a MemoryStream, so we can't use a FileStream directly
+            var stream = new MemoryStream(File.ReadAllBytes(Helper.GetTestWorkbookPath("Test_Git_Issue_184")));
+            var excelReader = ExcelReaderFactory.CreateBinaryReader(stream, true);
+
+            var ds = excelReader.AsDataSet(true);
+            Assert.IsNotNull(ds);
+            Assert.AreEqual(12, ds.Tables.Count, "Tables.Count");
+
+            var expectedRowCounts = new[] {1592, 5119, 5099, 4842, 5099, 5099, 4842, 5099, 5099, 5099, 5099, 6872};
+            for (int i=0; i<ds.Tables.Count; i++)
+                Assert.AreEqual(expectedRowCounts[i], ds.Tables[i].Rows.Count, "Tables[{0}].Rows.Count", i);
+        }
         
         [TestMethod]
         public void AsDataSet_Test()

--- a/Excel/Core/BinaryFormat/Enums.cs
+++ b/Excel/Core/BinaryFormat/Enums.cs
@@ -21,7 +21,8 @@ namespace ExcelDataReader.Portable.Core.BinaryFormat
 		FAT_EndOfChain = 0xFFFFFFFE,
 		FAT_FreeSpace = 0xFFFFFFFF,
 		FAT_FatSector = 0xFFFFFFFD,
-		FAT_DifSector = 0xFFFFFFFC
+		FAT_DifSector = 0xFFFFFFFC,
+		FAT_MaxRegSector = 0xFFFFFFFA
 	}
 
 	internal enum BIFFTYPE : ushort

--- a/Excel/Core/BinaryFormat/XlsHeader.cs
+++ b/Excel/Core/BinaryFormat/XlsHeader.cs
@@ -253,7 +253,7 @@ namespace ExcelDataReader.Portable.Core.BinaryFormat
 							break;
 						if ((difCount--) > 1)
 							difSector = value;
-						else
+						else if (value <= (uint)FATMARKERS.FAT_MaxRegSector)
 							sectors.Add(value);
 					}
 				}


### PR DESCRIPTION
When creating a binary reader with MemoryStreams containing workbooks of certain sizes, an ArgumentOutOfRangeException will no longer be thrown when attempting to read the FAT sectors. 

This resolves issue #184.