### PR TITLE
Change the main namespace to "ExcelDataReader" from "Excel"

### DIFF
--- a/src/ExcelDataReader.DataSet/DataColumn.cs
+++ b/src/ExcelDataReader.DataSet/DataColumn.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Linq;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public class DataColumn
     {

--- a/src/ExcelDataReader.DataSet/DataColumnCollection.cs
+++ b/src/ExcelDataReader.DataSet/DataColumnCollection.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public class DataColumnCollection : IEnumerable<DataColumn>
     {

--- a/src/ExcelDataReader.DataSet/DataRow.cs
+++ b/src/ExcelDataReader.DataSet/DataRow.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Linq;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public class DataRow
     {

--- a/src/ExcelDataReader.DataSet/DataRowCollection.cs
+++ b/src/ExcelDataReader.DataSet/DataRowCollection.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public class DataRowCollection : IEnumerable<DataRow>
     {

--- a/src/ExcelDataReader.DataSet/DataSet.cs
+++ b/src/ExcelDataReader.DataSet/DataSet.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public class DataSet
     {

--- a/src/ExcelDataReader.DataSet/DataTable.cs
+++ b/src/ExcelDataReader.DataSet/DataTable.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Linq;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public class DataTable
     {

--- a/src/ExcelDataReader.DataSet/DataTableCollection.cs
+++ b/src/ExcelDataReader.DataSet/DataTableCollection.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public class DataTableCollection : IEnumerable<DataTable>
     {

--- a/src/ExcelDataReader.DataSet/ExcelDataReaderExtensions.cs
+++ b/src/ExcelDataReader.DataSet/ExcelDataReaderExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public static class ExcelDataReaderExtensions
     {

--- a/src/ExcelDataReader.DataSet/PropertyCollection.cs
+++ b/src/ExcelDataReader.DataSet/PropertyCollection.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public class PropertyCollection : IEnumerable<KeyValuePair<string, string>>
     {

--- a/src/ExcelDataReader/Core/BinaryFormat/IXlsString.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/IXlsString.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     internal interface IXlsString

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffBOF.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffBOF.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffBlankCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffBlankCell.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffBoundSheet.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffBoundSheet.cs
@@ -1,7 +1,5 @@
 using System.Text;
 
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffContinue.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffContinue.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffDbCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffDbCell.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffDimensions.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffDimensions.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffEOF.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffEOF.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffFilePass.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffFilePass.cs
@@ -1,7 +1,5 @@
 using System;
 
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffFormatString.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffFormatString.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Text;
-
-using Excel;
 
 namespace ExcelDataReader.Core.BinaryFormat
 {

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffFormulaCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffFormulaCell.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Text;
 
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffFormulaString.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffFormulaString.cs
@@ -1,7 +1,3 @@
-using System.Text;
-
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffIndex.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffIndex.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffIntegerCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffIntegerCell.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffInterfaceHdr.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffInterfaceHdr.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffLabelCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffLabelCell.cs
@@ -1,7 +1,3 @@
-using System.Text;
-
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffLabelSSTCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffLabelSSTCell.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffMSODrawing.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffMSODrawing.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffMulBlankCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffMulBlankCell.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffMulRKCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffMulRKCell.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffNumberCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffNumberCell.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffQuickTip.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffQuickTip.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffRKCell.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffRKCell.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffRecord.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffRecord.cs
@@ -1,5 +1,4 @@
 using System;
-using Excel;
 
 namespace ExcelDataReader.Core.BinaryFormat
 {

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffRow.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffRow.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffSST.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffSST.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
-using Excel;
 
 namespace ExcelDataReader.Core.BinaryFormat
 {

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffSimpleValueRecord.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffSimpleValueRecord.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffStream.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffStream.cs
@@ -2,8 +2,6 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffUncalced.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffUncalced.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     /// <summary>

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffWindow1.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffWindow1.cs
@@ -1,5 +1,4 @@
 using System;
-using Excel;
 
 namespace ExcelDataReader.Core.BinaryFormat
 {

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsDirectoryEntry.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsDirectoryEntry.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Text;
-using Excel;
 using ExcelDataReader.Exceptions;
 
 namespace ExcelDataReader.Core.BinaryFormat

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsFat.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsFat.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Excel;
 
 namespace ExcelDataReader.Core.BinaryFormat
 {

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsStringFactory.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsStringFactory.cs
@@ -1,5 +1,3 @@
-using Excel;
-
 namespace ExcelDataReader.Core.BinaryFormat
 {
     internal class XlsStringFactory

--- a/src/ExcelDataReader/Errors.cs
+++ b/src/ExcelDataReader/Errors.cs
@@ -1,4 +1,4 @@
-namespace Excel
+namespace ExcelDataReader
 {
     internal static class Errors
     {

--- a/src/ExcelDataReader/ExcelBinaryReader.cs
+++ b/src/ExcelDataReader/ExcelBinaryReader.cs
@@ -10,7 +10,7 @@ using ExcelDataReader.Exceptions;
 using ExcelDataReader.Log;
 using ExcelDataReader.Misc;
 
-namespace Excel
+namespace ExcelDataReader
 {
     /// <summary>
     /// Strict is as normal, Loose is more forgiving and will not cause an exception if a record size takes it beyond the end of the file. It will be trunacted in this case (SQl Reporting Services)

--- a/src/ExcelDataReader/ExcelOpenXmlReader.cs
+++ b/src/ExcelDataReader/ExcelOpenXmlReader.cs
@@ -10,7 +10,7 @@ using System.Xml;
 using ExcelDataReader.Core;
 using ExcelDataReader.Core.OpenXmlFormat;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public partial class ExcelOpenXmlReader : IExcelDataReader
     {

--- a/src/ExcelDataReader/ExcelReaderFactory.cs
+++ b/src/ExcelDataReader/ExcelReaderFactory.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using ExcelDataReader.Core.BinaryFormat;
 
-namespace Excel
+namespace ExcelDataReader
 {
     /// <summary>
     /// The ExcelReader Factory

--- a/src/ExcelDataReader/IExcelDataReader.cs
+++ b/src/ExcelDataReader/IExcelDataReader.cs
@@ -2,7 +2,7 @@ using System;
 using System.Data;
 using System.Text;
 
-namespace Excel
+namespace ExcelDataReader
 {
     public interface IExcelDataReader : IDataReader
     {

--- a/src/TestApp/Form1.cs
+++ b/src/TestApp/Form1.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Windows.Forms;
-using Excel;
+using ExcelDataReader;
 
 namespace TestApp
 {

--- a/test/ExcelDataReader.Tests/AssertUtilities.cs
+++ b/test/ExcelDataReader.Tests/AssertUtilities.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Data;
 
-using Excel;
-
 using NUnit.Framework;
 
 namespace ExcelDataReader.Tests

--- a/test/ExcelDataReader.Tests/ExcelBinaryReaderTest.cs
+++ b/test/ExcelDataReader.Tests/ExcelBinaryReaderTest.cs
@@ -3,7 +3,6 @@
 using System.Data;
 #endif
 using System.IO;
-using Excel;
 using ExcelDataReader.Exceptions;
 
 using NUnit.Framework;

--- a/test/ExcelDataReader.Tests/ExcelOpenXmlReaderLocaleTest.cs
+++ b/test/ExcelDataReader.Tests/ExcelOpenXmlReaderLocaleTest.cs
@@ -1,7 +1,6 @@
 ﻿#if NET20 || NET45
 using System.Globalization;
 using System.Threading;
-using Excel;
 using NUnit.Framework;
 using TestClass = NUnit.Framework.TestFixtureAttribute;
 using TestMethod = NUnit.Framework.TestAttribute;

--- a/test/ExcelDataReader.Tests/ExcelOpenXmlReaderTest.cs
+++ b/test/ExcelDataReader.Tests/ExcelOpenXmlReaderTest.cs
@@ -9,7 +9,6 @@ using System.IO;
 #if NET20 || NET45
 using System.Threading;
 #endif
-using Excel;
 
 using NUnit.Framework;
 using TestClass = NUnit.Framework.TestFixtureAttribute;


### PR DESCRIPTION
Suggest this breaking change as part of 3.0. Now is a good time to get naming consistent across project, package, namespace and assembly dlls