### PR TITLE
Removed record size check so that Read returns null for trunkated rec…

### DIFF
--- a/src/ExcelDataReader/Core/BinaryFormat/XlsBiffStream.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsBiffStream.cs
@@ -126,9 +126,6 @@ namespace ExcelDataReader.Core.BinaryFormat
 
             if (record != null)
             {
-                if (record.Bytes.Length < Position + record.Size)
-                    throw new ArgumentException(Errors.ErrorBiffBufferSize);
-
                 Position += record.Size;
             }
 

--- a/src/ExcelDataReader/Errors.cs
+++ b/src/ExcelDataReader/Errors.cs
@@ -10,7 +10,6 @@ namespace ExcelDataReader
         public const string ErrorHeaderSignature = "Invalid file signature.";
         public const string ErrorHeaderOrder = "Invalid byte order specified in header.";
         public const string ErrorBiffRecordSize = "Buffer size is less than minimum BIFF record size.";
-        public const string ErrorBiffBufferSize = "BIFF Stream error: Buffer size is less than entry length.";
         public const string ErrorBiffIlegalBefore = "BIFF Stream error: Moving before stream start.";
         public const string ErrorBiffIlegalAfter = "BIFF Stream error: Moving after stream end.";
 


### PR DESCRIPTION
…ords when trunkated after the first 4 bytes. Previously it returned null if trunkated before 4 bytes and threw an ArgumentException when trunkated after.

Changed as discussed in #229. 