### PR TITLE
Don't try to parse empty directory entries

### DIFF
--- a/src/ExcelDataReader/Core/CompoundFormat/CompoundDocument.cs
+++ b/src/ExcelDataReader/Core/CompoundFormat/CompoundDocument.cs
@@ -191,13 +191,24 @@ namespace ExcelDataReader.Core.CompoundFormat
             var result = new CompoundDirectoryEntry();
             var name = reader.ReadBytes(64);
             var nameLength = reader.ReadUInt16();
-
-            if (nameLength > 0)
+            var entryType = (STGTY)reader.ReadByte();
+            
+            if (entryType == STGTY.STGTY_INVALID)
+            {
+                // free/unused directory entry
+                // stream should be zeroes, except for child, right, left sid which should be NOSTREAM
+                reader.ReadBytes(61);
+                result.LeftSiblingSid = result.RightSiblingSid = result.ChildSid = 0xFFFFFFFF;
+                result.CreationTime = result.LastWriteTime = DateTime.FromFileTime(0);
+                return result;
+            }
+            
+            if (nameLength > 0)
             {
                 result.EntryName = Encoding.Unicode.GetString(name, 0, nameLength).TrimEnd('\0');
             }
-
-            result.EntryType = (STGTY)reader.ReadByte();
+            
+            result.EntryType = entryType;
             result.EntryColor = (DECOLOR)reader.ReadByte();
             result.LeftSiblingSid = reader.ReadUInt32();
             result.RightSiblingSid = reader.ReadUInt32();

--- a/src/ExcelDataReader/Core/CompoundFormat/CompoundDocument.cs
+++ b/src/ExcelDataReader/Core/CompoundFormat/CompoundDocument.cs
@@ -191,24 +191,24 @@ namespace ExcelDataReader.Core.CompoundFormat
             var result = new CompoundDirectoryEntry();
             var name = reader.ReadBytes(64);
             var nameLength = reader.ReadUInt16();
+
             var entryType = (STGTY)reader.ReadByte();
-            
-            if (entryType == STGTY.STGTY_INVALID)
+            if (entryType == STGTY.STGTY_INVALID)
             {
                 // free/unused directory entry
-                // stream should be zeroes, except for child, right, left sid which should be NOSTREAM
+                // entire stream should be zeroes, except for child, right, left sid which should be NOSTREAM
                 reader.ReadBytes(61);
                 result.LeftSiblingSid = result.RightSiblingSid = result.ChildSid = 0xFFFFFFFF;
                 result.CreationTime = result.LastWriteTime = DateTime.FromFileTime(0);
                 return result;
             }
-            
-            if (nameLength > 0)
+
+            if (nameLength > 0)
             {
                 result.EntryName = Encoding.Unicode.GetString(name, 0, nameLength).TrimEnd('\0');
             }
-            
-            result.EntryType = entryType;
+
+            result.EntryType = entryType;
             result.EntryColor = (DECOLOR)reader.ReadByte();
             result.LeftSiblingSid = reader.ReadUInt32();
             result.RightSiblingSid = reader.ReadUInt32();


### PR DESCRIPTION
Avoid DateTime.FromFileTime throwing exceptions when free/unused entries (EntryType == STGTY_INVALID) contain junk bytes.