### PR TITLE
changed target framework to net35 for ExcelDataReader.DataSet

### DIFF
--- a/src/ExcelDataReader.DataSet/ExcelDataReader.DataSet.csproj
+++ b/src/ExcelDataReader.DataSet/ExcelDataReader.DataSet.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>ExcelDataReader.DataSet</AssemblyTitle>
     <VersionPrefix>3.4.1</VersionPrefix>
     <Authors>ExcelDataReader developers</Authors>
-    <TargetFrameworks>net20;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net35;netstandard2.0</TargetFrameworks>
     <AssemblyName>ExcelDataReader.DataSet</AssemblyName>
     <AssemblyOriginatorKeyFile>..\ExcelDataReader.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Using the net20 binaries in VS2010 with .Net 4.0 as target framework leads to the compile error "Missing compiler required member System.Runtime.CompilerServices.ExtensionAttribute..ctor".
Changing the target framework to net35 for ExcelDataReader.DataSet fix this issue.