### PR TITLE
Optional parameter to force column Data Type

### DIFF
--- a/src/ExcelDataReader/ExcelDataType.cs
+++ b/src/ExcelDataReader/ExcelDataType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExcelDataReader
+{
+    /// <summary>
+    /// Represent a column data type.
+    /// </summary>
+    public class ExcelDataType
+    {
+        public string ColumnName { get; set; }
+        public Type ColumnType { get; set; }
+    }
+}

--- a/src/TestApp/Form1.cs
+++ b/src/TestApp/Form1.cs
@@ -262,6 +262,9 @@ namespace TestApp
 
                 var openTiming = sw.ElapsedMilliseconds;
                 // reader.IsFirstRowAsColumnNames = firstRowNamesCheckBox.Checked;
+
+                //  Uncomment the following line to use the ExcelDataType list optional param
+                //ds = reader.AsDataSet(new List<ExcelDataType> { new ExcelDataType() { ColumnName = "COLUMN_HEADER", ColumnType = typeof( decimal)} },new ExcelDataSetConfiguration()
                 ds = reader.AsDataSet(new ExcelDataSetConfiguration()
                 {
                     UseColumnDataType = false,


### PR DESCRIPTION
To the extension class "ExcelDataReaderExtensions" was added a new optional parameter. This new parameter allow specify the value type associated to a column. 

The structure of this parameter is a list of ExcelDataType.

The definition of an ExcelDataType is:

`public class ExcelDataType`
`{`
`public string ColumnName { get; set; }`
        `public Type ColumnType { get; set; }`
 `}`
