### PR TITLE
Assorted refactorings and optimizations:

### DIFF
--- a/src/ExcelDataReader/Core/BuiltinNumberFormat.cs
+++ b/src/ExcelDataReader/Core/BuiltinNumberFormat.cs
@@ -5,7 +5,7 @@ namespace ExcelDataReader.Core
 {
     internal static class BuiltinNumberFormat
     {
-        private static Dictionary<int, NumberFormatString> Formats { get; } = new Dictionary<int, NumberFormatString>()
+        private static IReadOnlyDictionary<int, NumberFormatString> Formats { get; } = new Dictionary<int, NumberFormatString>
         {
             { 0, new NumberFormatString("General") },
             { 1, new NumberFormatString("0") },

--- a/src/ExcelDataReader/Core/BuiltinNumberFormat.cs
+++ b/src/ExcelDataReader/Core/BuiltinNumberFormat.cs
@@ -5,7 +5,7 @@ namespace ExcelDataReader.Core
 {
     internal static class BuiltinNumberFormat
     {
-        private static IReadOnlyDictionary<int, NumberFormatString> Formats { get; } = new Dictionary<int, NumberFormatString>
+        private static Dictionary<int, NumberFormatString> Formats { get; } = new Dictionary<int, NumberFormatString>
         {
             { 0, new NumberFormatString("General") },
             { 1, new NumberFormatString("0") },

--- a/src/ExcelDataReader/Core/Helpers.cs
+++ b/src/ExcelDataReader/Core/Helpers.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -11,7 +10,7 @@ namespace ExcelDataReader.Core
     /// </summary>
     internal static class Helpers
     {
-        private static readonly Regex EscapeRegex = new("_x([0-9A-F]{4,4})_");
+        private static readonly Regex EscapeRegex = new("_x([0-9A-F]{4,4})_", RegexOptions.Compiled);
 
         /// <summary>
         /// Determines whether the encoding is single byte or not.

--- a/src/ExcelDataReader/Core/OpenXmlFormat/Records/Record.cs
+++ b/src/ExcelDataReader/Core/OpenXmlFormat/Records/Record.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ExcelDataReader.Core.OpenXmlFormat.Records
+﻿namespace ExcelDataReader.Core.OpenXmlFormat.Records
 {
     internal abstract class Record
     {

--- a/src/ExcelDataReader/Core/OpenXmlFormat/ZipWorker.cs
+++ b/src/ExcelDataReader/Core/OpenXmlFormat/ZipWorker.cs
@@ -64,27 +64,27 @@ namespace ExcelDataReader.Core.OpenXmlFormat
             using var reader = XmlReader.Create(workbookRelsEntry.Open(), XmlSettings);
             while (reader.Read())
             {
-                if (reader.NodeType == XmlNodeType.Element && reader.Name == "Relationship")
-                {
-                    var id = reader.GetAttribute("Id");
-                    var type = reader.GetAttribute("Type");
-                    var target = reader.GetAttribute("Target");
+                if (reader.NodeType != XmlNodeType.Element || reader.Name != "Relationship")
+                    continue;
 
-                    switch (type)
-                    {
-                        case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet":
-                        case "http://purl.oclc.org/ooxml/officeDocument/relationships/worksheet":
-                            _worksheetRels[id] = ResolvePath(basePath, target);
-                            break;
-                        case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles":
-                        case "http://purl.oclc.org/ooxml/officeDocument/relationships/styles":
-                            _fileStyles = ResolvePath(basePath, target);
-                            break;
-                        case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings":
-                        case "http://purl.oclc.org/ooxml/officeDocument/relationships/sharedStrings":
-                            _fileSharedStrings = ResolvePath(basePath, target);
-                            break;
-                    }
+                var id = reader.GetAttribute("Id");
+                var type = reader.GetAttribute("Type");
+                var target = reader.GetAttribute("Target");
+
+                switch (type)
+                {
+                    case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet":
+                    case "http://purl.oclc.org/ooxml/officeDocument/relationships/worksheet":
+                        _worksheetRels[id] = ResolvePath(basePath, target);
+                        break;
+                    case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles":
+                    case "http://purl.oclc.org/ooxml/officeDocument/relationships/styles":
+                        _fileStyles = ResolvePath(basePath, target);
+                        break;
+                    case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings":
+                    case "http://purl.oclc.org/ooxml/officeDocument/relationships/sharedStrings":
+                        _fileSharedStrings = ResolvePath(basePath, target);
+                        break;
                 }
             }
 
@@ -112,17 +112,17 @@ namespace ExcelDataReader.Core.OpenXmlFormat
                 using var reader = XmlReader.Create(entry.Open(), XmlSettings);
                 while (reader.Read())
                 {
-                    if (reader.NodeType == XmlNodeType.Element && reader.Name == "Relationship")
-                    {
-                        var type = reader.GetAttribute("Type");
-                        var target = reader.GetAttribute("Target");
+                    if (reader.NodeType != XmlNodeType.Element || reader.Name != "Relationship")
+                        continue;
 
-                        switch (type)
-                        {
-                            case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument":
-                            case "http://purl.oclc.org/ooxml/officeDocument/relationships/officeDocument":
-                                return target;
-                        }
+                    var type = reader.GetAttribute("Type");
+                    var target = reader.GetAttribute("Target");
+
+                    switch (type)
+                    {
+                        case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument":
+                        case "http://purl.oclc.org/ooxml/officeDocument/relationships/officeDocument":
+                            return target;
                     }
                 }
 

--- a/src/ExcelDataReader/Misc/DateTimeHelper.cs
+++ b/src/ExcelDataReader/Misc/DateTimeHelper.cs
@@ -55,7 +55,7 @@ namespace ExcelDataReader.Misc
         internal static long DoubleDateToTicks(double value)
         {
             if (value >= OADateMaxAsDouble || value <= OADateMinAsDouble)
-                throw new ArgumentException("Invalid OA Date");
+                throw new ArgumentException("Invalid OA Date", nameof(value));
             long millis = (long)(value * MillisPerDay + (value >= 0 ? 0.5 : -0.5));
 
             // The interesting thing here is when you have a value like 12.5 it all positive 12 days and 12 hours from 01/01/1899


### PR DESCRIPTION
- Removed unnecessary usings
- Removed block nesting levels in a few places
- Made BuiltinNumberFormat.Formats explicitly read-only, as it's never modified
- Made Helpers.EscapeRegex compiled