### PR TITLE
Handle the partial-byte-reads-in-stream breaking change in .NET6

### DIFF
--- a/src/ExcelDataReader/Core/OpenXmlFormat/BinaryFormat/BiffReader.cs
+++ b/src/ExcelDataReader/Core/OpenXmlFormat/BinaryFormat/BiffReader.cs
@@ -27,7 +27,7 @@ namespace ExcelDataReader.Core.OpenXmlFormat.BinaryFormat
                 return null;
 
             byte[] buffer = recordLength < _buffer.Length ? _buffer : new byte[recordLength];
-            if (Stream.Read(buffer, 0, (int)recordLength) != recordLength)
+            if (Stream.ReadAtLeast(buffer, 0, (int)recordLength) != recordLength)
                 return null;
 
             return ReadOverride(buffer, recordId, recordLength);


### PR DESCRIPTION
**Issue** 
When the client application uses .NET6+, large xlsb files may not be parsed correctly

**Cause**
The was a [breaking change introduced in .NET 6](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams) that makes the DeflateStream behave differently than currently expected in BiffReader.cs

**Fix**
If the framework is .NET 6 onwards, the stream read logic needs to be handled differently


Closes #637 