### PR TITLE
Add CustomQuoteCharacter for reading csv files

### DIFF
--- a/src/ExcelDataReader/Core/CsvFormat/CsvAnalyzer.cs
+++ b/src/ExcelDataReader/Core/CsvFormat/CsvAnalyzer.cs
@@ -5,11 +5,11 @@ namespace ExcelDataReader.Core.CsvFormat;
 internal static class CsvAnalyzer
 {
     /// <summary>
-    /// Reads completely through a CSV stream to determine encoding, separator, field count and row count. 
+    /// Reads completely through a CSV stream to determine encoding, separator, field count and row count.
     /// Uses fallbackEncoding if there is no BOM. Throws DecoderFallbackException if there are invalid characters in the stream.
     /// Returns the separator whose average field count is closest to its max field count.
     /// </summary>
-    public static void Analyze(Stream stream, char[] separators, Encoding fallbackEncoding, int analyzeInitialCsvRows, out int fieldCount, out char autodetectSeparator, out Encoding autodetectEncoding, out int bomLength, out int rowCount)
+    public static void Analyze(Stream stream, char[] separators, Encoding fallbackEncoding, int analyzeInitialCsvRows, char? quoteChar, out int fieldCount, out char autodetectSeparator, out Encoding autodetectEncoding, out int bomLength, out int rowCount)
     {
         var bufferSize = 1024;
         var probeSize = 16;
@@ -29,7 +29,7 @@ internal static class CsvAnalyzer
         {
             separatorInfos[i] = new SeparatorInfo
             {
-                Buffer = new CsvParser(separators[i], autodetectEncoding)
+                Buffer = new CsvParser(separators[i], autodetectEncoding, quoteChar)
             };
         }
 

--- a/src/ExcelDataReader/Core/CsvFormat/CsvWorkbook.cs
+++ b/src/ExcelDataReader/Core/CsvFormat/CsvWorkbook.cs
@@ -3,7 +3,7 @@ using ExcelDataReader.Core.NumberFormat;
 
 namespace ExcelDataReader.Core.CsvFormat;
 
-internal sealed class CsvWorkbook(Stream stream, Encoding encoding, char[] autodetectSeparators, int analyzeInitialCsvRows) : IWorkbook<CsvWorksheet>
+internal sealed class CsvWorkbook(Stream stream, Encoding encoding, char[] autodetectSeparators, int analyzeInitialCsvRows, char? quoteChar = null) : IWorkbook<CsvWorksheet>
 {
     public int ResultsCount => 1;
 
@@ -13,13 +13,15 @@ internal sealed class CsvWorkbook(Stream stream, Encoding encoding, char[] autod
 
     public Encoding Encoding { get; } = encoding;
 
+    public char? QuoteChar { get; } = quoteChar;
+
     public char[] AutodetectSeparators { get; } = autodetectSeparators;
 
     public int AnalyzeInitialCsvRows { get; } = analyzeInitialCsvRows;
 
     public IEnumerable<CsvWorksheet> ReadWorksheets()
     {
-        yield return new CsvWorksheet(Stream, Encoding, AutodetectSeparators, AnalyzeInitialCsvRows);
+        yield return new CsvWorksheet(Stream, Encoding, AutodetectSeparators, AnalyzeInitialCsvRows, QuoteChar);
     }
 
     public NumberFormatString GetNumberFormatString(int index)

--- a/src/ExcelDataReader/Core/CsvFormat/CsvWorksheet.cs
+++ b/src/ExcelDataReader/Core/CsvFormat/CsvWorksheet.cs
@@ -4,14 +4,15 @@ namespace ExcelDataReader.Core.CsvFormat;
 
 internal sealed class CsvWorksheet : IWorksheet
 {
-    public CsvWorksheet(Stream stream, Encoding fallbackEncoding, char[] autodetectSeparators, int analyzeInitialCsvRows)
+    public CsvWorksheet(Stream stream, Encoding fallbackEncoding, char[] autodetectSeparators, int analyzeInitialCsvRows, char? quoteChar = null)
     {
         Stream = stream;
+        QuoteChar = quoteChar;
         Stream.Seek(0, SeekOrigin.Begin);
         try
         {
             // Try as UTF-8 first, or use BOM if present
-            CsvAnalyzer.Analyze(Stream, autodetectSeparators, Encoding.UTF8, analyzeInitialCsvRows, out var fieldCount, out var separator, out var encoding, out var bomLength, out var rowCount);
+            CsvAnalyzer.Analyze(Stream, autodetectSeparators, Encoding.UTF8, analyzeInitialCsvRows, quoteChar, out var fieldCount, out var separator, out var encoding, out var bomLength, out var rowCount);
             FieldCount = fieldCount;
             AnalyzedRowCount = rowCount;
             AnalyzedPartial = analyzeInitialCsvRows > 0;
@@ -24,7 +25,7 @@ internal sealed class CsvWorksheet : IWorksheet
             // If cannot parse as UTF-8, try fallback encoding
             Stream.Seek(0, SeekOrigin.Begin);
 
-            CsvAnalyzer.Analyze(Stream, autodetectSeparators, fallbackEncoding, analyzeInitialCsvRows, out var fieldCount, out var separator, out var encoding, out var bomLength, out var rowCount);
+            CsvAnalyzer.Analyze(Stream, autodetectSeparators, fallbackEncoding, analyzeInitialCsvRows, quoteChar, out var fieldCount, out var separator, out var encoding, out var bomLength, out var rowCount);
             FieldCount = fieldCount;
             AnalyzedRowCount = rowCount;
             AnalyzedPartial = analyzeInitialCsvRows > 0;
@@ -67,6 +68,8 @@ internal sealed class CsvWorksheet : IWorksheet
 
     public Encoding Encoding { get; }
 
+    public char? QuoteChar { get; }
+
     public char Separator { get; }
 
     public Column[] ColumnWidths => null;
@@ -82,7 +85,7 @@ internal sealed class CsvWorksheet : IWorksheet
         var bufferSize = 1024;
         var buffer = new byte[bufferSize];
         var rowIndex = 0;
-        var csv = new CsvParser(Separator, Encoding);
+        var csv = new CsvParser(Separator, Encoding, QuoteChar);
         var skipBomBytes = BomLength;
 
         Stream.Seek(0, SeekOrigin.Begin);

--- a/src/ExcelDataReader/ExcelCsvReader.cs
+++ b/src/ExcelDataReader/ExcelCsvReader.cs
@@ -5,9 +5,9 @@ namespace ExcelDataReader;
 
 internal sealed class ExcelCsvReader : ExcelDataReader<CsvWorkbook, CsvWorksheet>
 {
-    public ExcelCsvReader(Stream stream, Encoding fallbackEncoding, char[] autodetectSeparators, int analyzeInitialCsvRows)
+    public ExcelCsvReader(Stream stream, Encoding fallbackEncoding, char[] autodetectSeparators, int analyzeInitialCsvRows, char? quoteChar = null)
     {
-        Workbook = new CsvWorkbook(stream, fallbackEncoding, autodetectSeparators, analyzeInitialCsvRows);
+        Workbook = new CsvWorkbook(stream, fallbackEncoding, autodetectSeparators, analyzeInitialCsvRows, quoteChar);
 
         // By default, the data reader is positioned on the first result.
         Reset();

--- a/src/ExcelDataReader/ExcelReaderConfiguration.cs
+++ b/src/ExcelDataReader/ExcelReaderConfiguration.cs
@@ -8,7 +8,7 @@ namespace ExcelDataReader;
 public class ExcelReaderConfiguration
 {
     /// <summary>
-    /// Gets or sets a value indicating the encoding to use when the input XLS lacks a CodePage record, 
+    /// Gets or sets a value indicating the encoding to use when the input XLS lacks a CodePage record,
     /// or when the input CSV lacks a BOM and does not parse as UTF8. Default: cp1252. (XLS BIFF2-5 and CSV only).
     /// </summary>
     public Encoding FallbackEncoding { get; set; } = Encoding.GetEncoding(1252);
@@ -22,6 +22,11 @@ public class ExcelReaderConfiguration
     /// Gets or sets an array of CSV separator candidates. The reader autodetects which best fits the input data. Default: , ; TAB | # (CSV only).
     /// </summary>
     public char[] AutodetectSeparators { get; set; } = [',', ';', '\t', '|', '#'];
+
+    /// <summary>
+    /// Gets or sets a QuoteCharacter for CSV (Default '"').
+    /// </summary>
+    public char? QuoteChar { get; set; } = '"';
 
     /// <summary>
     /// Gets or sets a value indicating whether to leave the stream open after the IExcelDataReader object is disposed. Default: false.

--- a/src/ExcelDataReader/ExcelReaderFactory.cs
+++ b/src/ExcelDataReader/ExcelReaderFactory.cs
@@ -165,7 +165,7 @@ public static class ExcelReaderFactory
             fileStream = new LeaveOpenStream(fileStream);
         }
 
-        return new ExcelCsvReader(fileStream, configuration.FallbackEncoding, configuration.AutodetectSeparators, configuration.AnalyzeInitialCsvRows);
+        return new ExcelCsvReader(fileStream, configuration.FallbackEncoding, configuration.AutodetectSeparators, configuration.AnalyzeInitialCsvRows, configuration.QuoteChar);
     }
 
     private static bool TryGetWorkbook(Stream fileStream, CompoundDocument document, out Stream stream)


### PR DESCRIPTION
Hello all,

My name is Christopher, and we have been using your package in production for a couple of years now. I would like to thank you all for this excellent library—my colleagues and I really appreciate your work.

Initially, we thought the project wasn't being maintained anymore, which is why this pull request is coming so late.

We encountered an issue with one file import, where the file uses a custom quote character. We added support for this over a year ago, and it's been working well since then. 😀

I’ve noticed that this might resolve issue #580: "Cannot configure QuoteChar."

We would appreciate it if this could be included in a new version so that we no longer need to rely on a cloned repository.

If you need any changes or further assistance, please feel free to ask—I'd be happy to help!

Kind regards,
Christopher

(Edit)

After some checks, I remembered our specific problem: the CSV contained irregular fields with random quote characters, and additional quotes appeared randomly in subsequent rows and cells, which disrupted the CSV reading.