### PR TITLE
Fix MergeCells returning null for XLS files without merged cells

### DIFF
--- a/src/ExcelDataReader.Tests/ExcelCsvReaderTest.cs
+++ b/src/ExcelDataReader.Tests/ExcelCsvReaderTest.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Text;
 
 namespace ExcelDataReader.Tests;
@@ -593,5 +594,21 @@ public class ExcelCsvReaderTest
         reader.GetValues(row);
 
         Assert.That(row, Is.EqualTo(new object[] { "John", "Doe", "120 any st.", "\"Anytown\", WW", "08123" }));
+    }
+
+    [Test]
+    public void FillMergedCellsValueDoesNotCrashOnCsv()
+    {
+        using var excelReader = ExcelReaderFactory.CreateCsvReader(Configuration.GetTestWorkbook(Path.Combine("csv", "comma_in_quotes.csv")));
+        DataSet result = excelReader.AsDataSet(new ExcelDataSetConfiguration
+        {
+            ConfigureDataTable = _ => new ExcelDataTableConfiguration
+            {
+                FillMergedCellsValue = true
+            }
+        });
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Tables[0].Rows.Count, Is.EqualTo(2));
     }
 }

--- a/src/ExcelDataReader.Tests/ExcelTestBase.cs
+++ b/src/ExcelDataReader.Tests/ExcelTestBase.cs
@@ -1097,6 +1097,24 @@ public abstract class ExcelTestBase
         Assert.That(result.Tables[0].Rows[5][1], Is.EqualTo("Merge Cell 4"));
         Assert.That(result.Tables[0].Rows[5][2], Is.EqualTo("Merge Cell 4"));
     }
+
+    [Test]
+    public void AsDataSetFillMergedCellsValueWithNoMergeCells()
+    {
+        using IExcelDataReader excelReader = OpenReader("10x10");
+        DataSet result = excelReader.AsDataSet(new ExcelDataSetConfiguration
+        {
+            ConfigureDataTable = _ => new ExcelDataTableConfiguration
+            {
+                UseHeaderRow = true,
+                FillMergedCellsValue = true
+            }
+        });
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Tables[0].Rows.Count, Is.EqualTo(9));
+        Assert.That(result.Tables[0].Columns.Count, Is.EqualTo(10));
+    }
     
     protected IExcelDataReader OpenReader(string name)
     {

--- a/src/ExcelDataReader/Core/BinaryFormat/XlsWorksheet.cs
+++ b/src/ExcelDataReader/Core/BinaryFormat/XlsWorksheet.cs
@@ -650,8 +650,7 @@ internal sealed class XlsWorksheet : IWorksheet
             Workbook.AddNumberFormat(biffFormat.Key, biffFormat.Value.GetValue(Encoding));
         }
 
-        if (mergeCells.Count > 0)
-            MergeCells = mergeCells.ToArray();
+        MergeCells = mergeCells.ToArray();
 
         if (!SinglePassMode)
         {

--- a/src/ExcelDataReader/Core/CsvFormat/CsvWorksheet.cs
+++ b/src/ExcelDataReader/Core/CsvFormat/CsvWorksheet.cs
@@ -49,7 +49,7 @@ internal sealed class CsvWorksheet : IWorksheet
 
     public HeaderFooter HeaderFooter => null;
 
-    public CellRange[] MergeCells => null;
+    public CellRange[] MergeCells => [];
 
     public int FieldCount { get; }
 

--- a/src/ExcelDataReader/IExcelDataReader.cs
+++ b/src/ExcelDataReader/IExcelDataReader.cs
@@ -38,7 +38,7 @@ public interface IExcelDataReader : IDataReader
     HeaderFooter HeaderFooter { get; }
 
     /// <summary>
-    /// Gets the list of merged cell ranges.
+    /// Gets the list of merged cell ranges, or an empty array if there are none.
     /// </summary>
     CellRange[] MergeCells { get; }
 


### PR DESCRIPTION
XlsWorksheet only assigned MergeCells when the file contained merge cells, leaving it null for files with none. CsvWorksheet also returned null. XLSX and XLSB always return an empty array, so this was an inconsistency.

Since null carries no extra meaning over an empty array, make all implementations consistent: always return an empty array.

Calling AsDataSet with FillMergedCellsValue = true on files without merged cells (including all CSV files) previously threw ArgumentNullException. This fixes the crash.