### PR TITLE
Fix IDataReader.Depth semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The `AsDataSet()` extension method is a convenient helper for quickly getting th
 | `CodeName`                                                                              | returns the VBA code name identifier of the current sheet.                                                                                                                                                              |
 | `FieldCount`                                                                            | returns the number of columns in the current sheet.                                                                                                                                                                     |
 | `RowCount`                                                                              | returns the number of rows in the current sheet. This includes terminal empty rows which are otherwise excluded by AsDataSet(). Throws `InvalidOperationException` on CSV files when used with `AnalyzeInitialCsvRows`. |
+| `Depth`                                                                                 | always returns `0` because ExcelDataReader does not expose nested result sets.                                                                                                                                          |
 | `HeaderFooter`                                                                          | returns an object with information about the headers and footers, or `null` if there are none.                                                                                                                          |
 | `MergeCells`                                                                            | returns an array of merged cell ranges in the current sheet.                                                                                                                                                            |
 | `RowHeight`                                                                             | returns the visual height of the current row in points. May be 0 if the row is hidden.                                                                                                                                  |
@@ -216,12 +217,13 @@ var result = reader.AsDataSet(new ExcelDataSetConfiguration()
 Setting up `AsDataSet()` configuration, use the FilterRow callback to implement a "progress indicator" while loading, e.g.:
 
 ```c#
+int currentRow = 0;
 var result = reader.AsDataSet(new ExcelDataSetConfiguration()
 {
     ConfigureDataTable = (tableReader) => new ExcelDataTableConfiguration()
     {
         FilterRow = (rowReader) => {
-            int progress = (int)Math.Ceiling((decimal)rowReader.Depth / (decimal)rowReader.RowCount * (decimal)100);
+            int progress = (int)Math.Ceiling((decimal)++currentRow / (decimal)rowReader.RowCount * (decimal)100);
             // progress is in the range 0..100
             return true;
         }

--- a/src/ExcelDataReader.Tests/ExcelCsvReaderTest.cs
+++ b/src/ExcelDataReader.Tests/ExcelCsvReaderTest.cs
@@ -27,6 +27,21 @@ public class ExcelCsvReaderTest
     }
 
     [Test]
+    public void Issue443_DepthAlwaysZero_Csv()
+    {
+        using var reader = ExcelReaderFactory.CreateCsvReader(Configuration.GetTestWorkbook(Path.Combine("csv", "comma_in_quotes.csv")));
+        Assert.That(reader.Depth, Is.Zero);
+
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.Depth, Is.Zero);
+
+        while (reader.Read())
+        {
+            Assert.That(reader.Depth, Is.Zero);
+        }
+    }
+
+    [Test]
     public void CsvEscapedQuotes()
     {
         using var excelReader = ExcelReaderFactory.CreateCsvReader(Configuration.GetTestWorkbook(Path.Combine("csv", "escaped_quotes.csv")));

--- a/src/ExcelDataReader.Tests/ExcelTestBase.cs
+++ b/src/ExcelDataReader.Tests/ExcelTestBase.cs
@@ -759,6 +759,27 @@ public abstract class ExcelTestBase
     }
 
     [Test]
+    public void Issue443_DepthAlwaysZero()
+    {
+        using IExcelDataReader reader = OpenReader("MultiSheet");
+        Assert.That(reader.Depth, Is.Zero);
+
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.Depth, Is.Zero);
+
+        while (reader.Read())
+        {
+            Assert.That(reader.Depth, Is.Zero);
+        }
+
+        Assert.That(reader.NextResult(), Is.True);
+        Assert.That(reader.Depth, Is.Zero);
+
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.Depth, Is.Zero);
+    }
+
+    [Test]
     public void UnicodeCharsTest()
     {
         using IExcelDataReader excelReader = OpenReader("UnicodeChars");

--- a/src/ExcelDataReader/ExcelDataReader.cs
+++ b/src/ExcelDataReader/ExcelDataReader.cs
@@ -42,7 +42,7 @@ internal abstract class ExcelDataReader<TWorkbook, TWorksheet> : IExcelDataReade
     // We shouldn't expose the internal array here. 
     public CellRange[] MergeCells => _worksheetIterator?.Current?.MergeCells;
 
-    public int Depth { get; private set; }
+    public int Depth => 0;
 
     public int ResultsCount => Workbook?.ResultsCount ?? -1;
 
@@ -305,7 +305,6 @@ internal abstract class ExcelDataReader<TWorkbook, TWorksheet> : IExcelDataReade
 
         ReadCurrentRow();
 
-        Depth++;
         return true;
     }
 
@@ -357,7 +356,6 @@ internal abstract class ExcelDataReader<TWorkbook, TWorksheet> : IExcelDataReade
 
     private void ResetSheetData()
     {
-        Depth = -1;
         RowCells = null;
     }
 


### PR DESCRIPTION
It should always return 0 since ExcelDataReader does not support nested data sets. 

Fixes issue #443 