### PR TITLE
Handle non-seekable streams by copying them to MemoryStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ var reader = ExcelReaderFactory.CreateReader(stream, new ExcelReaderConfiguratio
 });
 ```
 
-`CreateReader()`, `CreateBinaryReader()`, and `CreateOpenXmlReader()` require seek support during probing and binary/compound parsing. If the input stream is non-seekable, ExcelDataReader copies it to a `MemoryStream` first.
+`CreateReader()`, `CreateBinaryReader()`, `CreateOpenXmlReader()`, and `CreateCsvReader()` require seek support during probing and parsing. If the input stream is non-seekable, ExcelDataReader copies it to a `MemoryStream` first.
 
 This is a 4.0 breaking behavior change: when a non-seekable stream is copied, the original source stream may be consumed even when `LeaveOpen = true`.
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ var reader = ExcelReaderFactory.CreateReader(stream, new ExcelReaderConfiguratio
 });
 ```
 
+`CreateReader()`, `CreateBinaryReader()`, and `CreateOpenXmlReader()` require seek support during probing and binary/compound parsing. If the input stream is non-seekable, ExcelDataReader copies it to a `MemoryStream` first.
+
+This is a 4.0 breaking behavior change: when a non-seekable stream is copied, the original source stream may be consumed even when `LeaveOpen = true`.
+
 ### AsDataSet() configuration options
 
 The `AsDataSet()` method accepts an optional configuration object to modify the behavior of the DataSet conversion:

--- a/src/ExcelDataReader.Tests/ExcelReaderFactoryTests.cs
+++ b/src/ExcelDataReader.Tests/ExcelReaderFactoryTests.cs
@@ -55,6 +55,16 @@ public class ExcelReaderFactoryTests
     }
 
     [Test]
+    public void CreateCsvReader_NonSeekableStream_Succeeds()
+    {
+        using var stream = Configuration.GetTestWorkbook(Path.Combine("csv", "MOCK_DATA.csv"));
+        using var nonSeekableStream = SeekErrorMemoryStream.CreateFromStream(stream);
+        using IExcelDataReader excelReader = ExcelReaderFactory.CreateCsvReader(nonSeekableStream);
+
+        Assert.That(excelReader.Read(), Is.True);
+    }
+
+    [Test]
     public void CreateReader_NonSeekableCopyFailure_DisposesSourceWhenLeaveOpenFalse()
     {
         var stream = new ThrowOnReadNonSeekableStream();

--- a/src/ExcelDataReader.Tests/ExcelReaderFactoryTests.cs
+++ b/src/ExcelDataReader.Tests/ExcelReaderFactoryTests.cs
@@ -21,4 +21,92 @@ public class ExcelReaderFactoryTests
         using IExcelDataReader excelReader = ExcelReaderFactory.CreateReader(Configuration.GetTestWorkbook(name));
         Assert.That(excelReader.GetType().Name, Is.EqualTo("ExcelOpenXmlReader"));
     }
+
+    [Test]
+    public void CreateReader_NonSeekableBinaryStream_Succeeds()
+    {
+        using var stream = Configuration.GetTestWorkbook("10x10.xls");
+        using var nonSeekableStream = SeekErrorMemoryStream.CreateFromStream(stream);
+        using IExcelDataReader excelReader = ExcelReaderFactory.CreateReader(nonSeekableStream);
+
+        Assert.That(excelReader.GetType().Name, Is.EqualTo("ExcelBinaryReader"));
+        Assert.That(excelReader.Read(), Is.True);
+    }
+
+    [Test]
+    public void CreateBinaryReader_NonSeekableStream_Succeeds()
+    {
+        using var stream = Configuration.GetTestWorkbook("10x10.xls");
+        using var nonSeekableStream = SeekErrorMemoryStream.CreateFromStream(stream);
+        using IExcelDataReader excelReader = ExcelReaderFactory.CreateBinaryReader(nonSeekableStream);
+
+        Assert.That(excelReader.Read(), Is.True);
+    }
+
+    [Test]
+    public void CreateOpenXmlReader_NonSeekableStream_Succeeds()
+    {
+        using var stream = Configuration.GetTestWorkbook("10x10.xlsx");
+        using var nonSeekableStream = SeekErrorMemoryStream.CreateFromStream(stream);
+        using IExcelDataReader excelReader = ExcelReaderFactory.CreateOpenXmlReader(nonSeekableStream);
+
+        Assert.That(excelReader.GetType().Name, Is.EqualTo("ExcelOpenXmlReader"));
+        Assert.That(excelReader.Read(), Is.True);
+    }
+
+    [Test]
+    public void CreateReader_NonSeekableCopyFailure_DisposesSourceWhenLeaveOpenFalse()
+    {
+        var stream = new ThrowOnReadNonSeekableStream();
+
+        Assert.Throws<IOException>(() => ExcelReaderFactory.CreateReader(stream));
+        Assert.That(stream.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void CreateReader_NonSeekableCopyFailure_DoesNotDisposeSourceWhenLeaveOpenTrue()
+    {
+        var stream = new ThrowOnReadNonSeekableStream();
+
+        Assert.Throws<IOException>(() => ExcelReaderFactory.CreateReader(stream, new ExcelReaderConfiguration { LeaveOpen = true }));
+        Assert.That(stream.IsDisposed, Is.False);
+        stream.Dispose();
+    }
+
+    private sealed class ThrowOnReadNonSeekableStream : Stream
+    {
+        public bool IsDisposed { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new IOException("Simulated read failure");
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
 }

--- a/src/ExcelDataReader/ExcelReaderFactory.cs
+++ b/src/ExcelDataReader/ExcelReaderFactory.cs
@@ -31,6 +31,8 @@ public static class ExcelReaderFactory
             fileStream = new LeaveOpenStream(fileStream);
         }
 
+        fileStream = GetSeekableStream(fileStream);
+
         var probe = new byte[8];
         fileStream.Seek(0, SeekOrigin.Begin);
         fileStream.ReadAtLeast(probe, 0, probe.Length);
@@ -82,6 +84,8 @@ public static class ExcelReaderFactory
             fileStream = new LeaveOpenStream(fileStream);
         }
 
+        fileStream = GetSeekableStream(fileStream);
+
         var probe = new byte[8];
         fileStream.Seek(0, SeekOrigin.Begin);
         fileStream.ReadAtLeast(probe, 0, probe.Length);
@@ -123,6 +127,8 @@ public static class ExcelReaderFactory
         {
             fileStream = new LeaveOpenStream(fileStream);
         }
+
+        fileStream = GetSeekableStream(fileStream);
 
         var probe = new byte[8];
         fileStream.Seek(0, SeekOrigin.Begin);
@@ -215,5 +221,20 @@ public static class ExcelReaderFactory
 
         stream = encryption.CreateEncryptedPackageStream(packageStream, secretKey);
         return true;
+    }
+
+    private static Stream GetSeekableStream(Stream fileStream)
+    {
+        if (fileStream.CanSeek)
+            return fileStream;
+
+        using (fileStream)
+        {
+            // LeaveOpen semantics are handled by wrapping the caller stream before this call.
+            var seekableStream = new MemoryStream();
+            fileStream.CopyTo(seekableStream);
+            seekableStream.Seek(0, SeekOrigin.Begin);
+            return seekableStream;
+        }
     }
 }

--- a/src/ExcelDataReader/ExcelReaderFactory.cs
+++ b/src/ExcelDataReader/ExcelReaderFactory.cs
@@ -171,6 +171,8 @@ public static class ExcelReaderFactory
             fileStream = new LeaveOpenStream(fileStream);
         }
 
+        fileStream = GetSeekableStream(fileStream);
+
         return new ExcelCsvReader(fileStream, configuration.FallbackEncoding, configuration.AutodetectSeparators, configuration.AnalyzeInitialCsvRows, configuration.QuoteChar, configuration.TrimWhiteSpace, configuration.EscapeChar);
     }
 

--- a/src/ExcelDataReader/ExcelReaderFactory.cs
+++ b/src/ExcelDataReader/ExcelReaderFactory.cs
@@ -25,13 +25,7 @@ public static class ExcelReaderFactory
     public static IExcelDataReader CreateReader(Stream fileStream, ExcelReaderConfiguration configuration = null)
     {
         configuration ??= new ExcelReaderConfiguration();
-
-        if (configuration.LeaveOpen)
-        {
-            fileStream = new LeaveOpenStream(fileStream);
-        }
-
-        fileStream = GetSeekableStream(fileStream);
+        fileStream = PrepareInputStream(fileStream, configuration);
 
         var probe = new byte[8];
         fileStream.Seek(0, SeekOrigin.Begin);
@@ -78,13 +72,7 @@ public static class ExcelReaderFactory
     public static IExcelDataReader CreateBinaryReader(Stream fileStream, ExcelReaderConfiguration configuration = null)
     {
         configuration ??= new ExcelReaderConfiguration();
-
-        if (configuration.LeaveOpen)
-        {
-            fileStream = new LeaveOpenStream(fileStream);
-        }
-
-        fileStream = GetSeekableStream(fileStream);
+        fileStream = PrepareInputStream(fileStream, configuration);
 
         var probe = new byte[8];
         fileStream.Seek(0, SeekOrigin.Begin);
@@ -122,13 +110,7 @@ public static class ExcelReaderFactory
     public static IExcelDataReader CreateOpenXmlReader(Stream fileStream, ExcelReaderConfiguration configuration = null)
     {
         configuration ??= new ExcelReaderConfiguration();
-
-        if (configuration.LeaveOpen)
-        {
-            fileStream = new LeaveOpenStream(fileStream);
-        }
-
-        fileStream = GetSeekableStream(fileStream);
+        fileStream = PrepareInputStream(fileStream, configuration);
 
         var probe = new byte[8];
         fileStream.Seek(0, SeekOrigin.Begin);
@@ -165,13 +147,7 @@ public static class ExcelReaderFactory
     public static IExcelDataReader CreateCsvReader(Stream fileStream, ExcelReaderConfiguration configuration = null)
     {
         configuration ??= new ExcelReaderConfiguration();
-
-        if (configuration.LeaveOpen)
-        {
-            fileStream = new LeaveOpenStream(fileStream);
-        }
-
-        fileStream = GetSeekableStream(fileStream);
+        fileStream = PrepareInputStream(fileStream, configuration);
 
         return new ExcelCsvReader(fileStream, configuration.FallbackEncoding, configuration.AutodetectSeparators, configuration.AnalyzeInitialCsvRows, configuration.QuoteChar, configuration.TrimWhiteSpace, configuration.EscapeChar);
     }
@@ -238,5 +214,15 @@ public static class ExcelReaderFactory
             seekableStream.Seek(0, SeekOrigin.Begin);
             return seekableStream;
         }
+    }
+
+    private static Stream PrepareInputStream(Stream fileStream, ExcelReaderConfiguration configuration)
+    {
+        if (configuration.LeaveOpen)
+        {
+            fileStream = new LeaveOpenStream(fileStream);
+        }
+
+        return GetSeekableStream(fileStream);
     }
 }


### PR DESCRIPTION
This is the same way that System.IO.Compression.ZipArchive works. 

Fixes issue #431 